### PR TITLE
[Toezicht module] Propagating new form adjustements for besluit handhaven form

### DIFF
--- a/config/migrations/2023/20230621124520-add-new-forms/20230621124520-add-file-resource.sparql
+++ b/config/migrations/2023/20230621124520-add-new-forms/20230621124520-add-file-resource.sparql
@@ -1,0 +1,20 @@
+PREFIX nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX dbpedia: <http://dbpedia.org/resource/>
+
+INSERT DATA {
+  GRAPH <http://mu.semte.ch/graphs/access-for-role/PubliekeBesluitendatabank-BesluitendatabankLezer> {
+    <share://semantic-forms/20230621124520-forms.ttl> a nfo:FileDataObject ;
+      dct:type <http://data.lblod.gift/concepts/form-file-type> ;
+      mu:uuid "6b9f4c71-1711-4c78-911e-cdb3a336960f" ;
+      nfo:fileName "20230621124520-forms.ttl" ;
+      dct:created "2023-06-21T12:45:20"^^xsd:dateTime ;
+      dct:modified "2023-06-21T12:45:20"^^xsd:dateTime ;
+      dct:format "text/turtle";
+      nfo:fileSize "355821"^^xsd:integer;
+      dbpedia:fileExtension "ttl" .
+  }
+}
+    

--- a/config/semantic-forms/20230621124520-forms.ttl
+++ b/config/semantic-forms/20230621124520-forms.ttl
@@ -1,0 +1,7342 @@
+@prefix form: <http://lblod.data.gift/vocabularies/forms/> .
+@prefix sh: <http://www.w3.org/ns/shacl#>.
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix mu: <http://mu.semte.ch/vocabularies/core/> .
+@prefix ext: <http://mu.semte.ch/vocabularies/ext/> .
+@prefix fieldGroups: <http://data.lblod.info/field-groups/> .
+@prefix fields: <http://data.lblod.info/fields/> .
+@prefix displayTypes: <http://lblod.data.gift/display-types/> .
+@prefix eli: <http://data.europa.eu/eli/ontology#>.
+@prefix besluit: <http://data.vlaanderen.be/ns/besluit#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix prov: <http://www.w3.org/ns/prov#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix lblodBesluit: <http://lblod.data.gift/vocabularies/besluit/> .
+@prefix besluit: <http://data.vlaanderen.be/ns/besluit#>.
+@prefix mandaat: <http://data.vlaanderen.be/ns/mandaat#>.
+@prefix elod: <http://linkedeconomy.org/ontology#>.
+@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
+@prefix nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#> .
+@prefix nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>.
+@prefix schema: <http://schema.org/>.
+# conditional fields are dynamic
+# TODO: fix groups (probably) too
+
+# TODO: extra validation: Only specific type of dossier should be availible to specific type of bestuurseenheid.
+# TODO: the list of dossiers to propose should differ from bestuurseenheidType to bestuurseenheidtype
+fields:0827fafe-ad19-49e1-8b2e-105d2c08a54a a form:Field ;
+    mu:uuid "0827fafe-ad19-49e1-8b2e-105d2c08a54a" ;
+    sh:name "Type dossier" ;
+    sh:order 100 ;
+    sh:path rdf:type ;
+    form:validations
+      [ a form:RequiredConstraint ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        sh:resultMessage "Dit veld is verplicht."@nl
+      ],
+      [ a form:ConceptSchemeConstraint ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        sh:resultMessage "Selecteer een waarde uit de lijst."@nl
+      ] ;
+    form:options  """{"conceptScheme":"http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5"}""" ;
+    form:displayType displayTypes:conceptSchemeSelector ;
+    sh:group fields:aDynamicPropertyGroup .
+
+fields:0cdfe85f-ec65-498f-bd26-0ec611967de0 a form:Field ;
+    mu:uuid "0cdfe85f-ec65-498f-bd26-0ec611967de0" ;
+    sh:name "Opmerking" ;
+    sh:order 500 ;
+    sh:path rdfs:comment ;
+    form:displayType displayTypes:textArea ;
+    sh:group fields:aDynamicPropertyGroup .
+
+fields:bd6ee5ac-22d6-4279-bcba-3ed279021aac a form:Field ;
+    mu:uuid "bd6ee5ac-22d6-4279-bcba-3ed279021aac" ;
+    sh:name "Dossieromschrijving" ;
+    sh:order 600 ;
+    sh:path dct:description ;
+    form:displayType displayTypes:textArea ;
+    sh:group fields:aDynamicPropertyGroup .
+
+fields:a8f6a6cb-dbb8-488c-878d-05603791a9eb a form:Field ;
+    mu:uuid "a8f6a6cb-dbb8-488c-878d-05603791a9eb" ;
+    sh:name "Gaat het over het origineel document of over een wijziging?" ;
+    sh:order 2100 ;
+    sh:path lblodBesluit:authenticityType ;
+    form:validations
+      [ a form:ConceptSchemeConstraint ; #TODO
+        form:grouping form:Bag ;
+        sh:path lblodBesluit:authenticityType ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/5cecec47-ba66-4d7a-ac9d-a1e7962ca4e2> ;
+        sh:resultMessage "Selecteer een waarde uit de lijst."@nl
+      ] ;
+    form:options  """{"conceptScheme":"http://lblod.data.gift/concept-schemes/5cecec47-ba66-4d7a-ac9d-a1e7962ca4e2"}""" ;
+    form:displayType displayTypes:conceptSchemeSelector ;
+    sh:group fields:aDynamicPropertyGroup .
+    
+###Origineel of wijziging voor erediensten ###
+fields:ea141dfa-80ff-4958-9493-c0cf6724cbf6 a form:Field ;
+    mu:uuid "ea141dfa-80ff-4958-9493-c0cf6724cbf6" ;
+    sh:name "Gaat het over het origineel document of over een wijziging?" ;
+    sh:order 2101 ;
+    sh:path lblodBesluit:authenticityType ;
+    form:validations
+    [ a form:RequiredConstraint ;
+        form:grouping form:Bag ;
+        sh:path lblodBesluit:authenticityType ;
+        sh:resultMessage "Dit veld is verplicht."@nl
+      ],
+      [ a form:ConceptSchemeConstraint ; #TODO
+        form:grouping form:Bag ;
+        sh:path lblodBesluit:authenticityType ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/91655ebf-5ab7-43c4-b587-094536baf737> ;
+        sh:resultMessage "Selecteer een waarde uit de lijst."@nl
+      ] ;
+    form:options  """{"conceptScheme":"http://lblod.data.gift/concept-schemes/91655ebf-5ab7-43c4-b587-094536baf737"}""" ;
+    form:displayType displayTypes:conceptSchemeSelector ;
+    sh:group fields:aDynamicPropertyGroup .
+
+
+    
+
+fields:e578e3ff-240b-421b-a32c-f411489c3806 a form:Field ;
+    mu:uuid "e578e3ff-240b-421b-a32c-f411489c3806" ;
+    sh:name "Rapportperiode" ;
+    sh:order 2200 ;
+    sh:path lblodBesluit:reportingPeriod ;
+    form:validations
+      [ a form:RequiredConstraint ;
+        form:grouping form:Bag ;
+        sh:path lblodBesluit:reportingPeriod ;
+        sh:resultMessage "Dit veld is verplicht."@nl
+      ],
+      [ a form:ConceptSchemeConstraint ; #TODO
+        form:grouping form:Bag ;
+        sh:path lblodBesluit:reportingPeriod ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/4e719768-d43b-4ca1-ab92-b463e15721f5> ;
+        sh:resultMessage "Selecteer een waarde uit de lijst."@nl
+      ] ;
+    form:options  """{"conceptScheme":"http://lblod.data.gift/concept-schemes/4e719768-d43b-4ca1-ab92-b463e15721f5"}""" ;
+    form:displayType displayTypes:conceptSchemeSelector ;
+    sh:group fields:aDynamicPropertyGroup .
+
+fields:b9d831c5-da21-40d6-aac8-65feb4783d76 a form:Field ;
+    mu:uuid "b9d831c5-da21-40d6-aac8-65feb4783d76" ;
+    sh:name "Gaat het over een voorlopige of definitieve vaststelling?" ;
+    sh:order 3800 ;
+    sh:path lblodBesluit:AdoptionType ;
+    form:validations
+      [ a form:RequiredConstraint ;
+        form:grouping form:Bag ;
+        sh:path lblodBesluit:AdoptionType ;
+        sh:resultMessage "Dit veld is verplicht."@nl
+      ],
+      [ a form:ConceptSchemeConstraint ;
+        form:grouping form:Bag ;
+        sh:path lblodBesluit:AdoptionType ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/a995bb71-3c87-4385-a06b-a786f2fa0d16>;
+        sh:resultMessage "Selecteer een waarde uit de lijst."@nl
+      ] ;
+    form:options  """{"conceptScheme":"http://lblod.data.gift/concept-schemes/a995bb71-3c87-4385-a06b-a786f2fa0d16"}""" ;
+    form:displayType displayTypes:conceptSchemeRadioButtons ;
+    sh:group fields:aDynamicPropertyGroup .
+
+fields:a7073ee1-3717-4798-ae10-fe69b29fabc1 a form:Field ;
+    mu:uuid "a7073ee1-3717-4798-ae10-fe69b29fabc1" ;
+    sh:name "Gaat het over een aanleg/verplaatsing/wijziging of over een opheffing van een gemeenteweg?" ;
+    sh:order 3900 ;
+    sh:path lblodBesluit:MunicipalRoadProcedureType ;
+    form:validations
+      [ a form:RequiredConstraint ;
+        form:grouping form:Bag ;
+        sh:path lblodBesluit:MunicipalRoadProcedureType ;
+        sh:resultMessage "Dit veld is verplicht."@nl
+      ],
+      [ a form:ConceptSchemeConstraint ;
+        form:grouping form:Bag ;
+        sh:path lblodBesluit:MunicipalRoadProcedureType ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/60d620a5-ec34-4a91-ba84-fff0813d0ccc>;
+        sh:resultMessage "Selecteer een waarde uit de lijst."@nl
+      ] ;
+    form:options  """{"conceptScheme":"http://lblod.data.gift/concept-schemes/60d620a5-ec34-4a91-ba84-fff0813d0ccc"}""" ;
+    form:displayType displayTypes:conceptSchemeRadioButtons ;
+    sh:group fields:aDynamicPropertyGroup .
+
+fields:6ffb0ed7-769a-41e4-b5a9-f6fb0287b235 a form:Field ;
+    mu:uuid "6ffb0ed7-769a-41e4-b5a9-f6fb0287b235" ;
+    sh:name "Ondernemingsnummer betreffend bedrijf/bestuur" ;
+    sh:order 900 ;
+    sh:path ( eli:is_about dct:identifier) ;
+    form:displayType displayTypes:defaultInput;
+    sh:group fields:aDynamicPropertyGroup .
+
+fields:78bfbd91-0778-4573-a52d-4c53b3c512eb a form:Field ;
+    mu:uuid "78bfbd91-0778-4573-a52d-4c53b3c512eb" ;
+    sh:name "Naam betreffend bedrijf/bestuur" ;
+    sh:order 1000 ;
+    sh:path ( eli:is_about skos:prefLabel) ;
+    form:validations
+      [ a form:RequiredConstraint ;
+        form:grouping form:Bag ;
+        sh:path ( eli:is_about skos:prefLabel ) ;
+        sh:resultMessage "Dit veld is verplicht."@nl
+      ];
+    form:displayType displayTypes:defaultInput;
+    sh:group fields:aDynamicPropertyGroup .
+
+fields:41737f90-02d6-4036-8d60-5d5b6ccf939c a form:Field ;
+    mu:uuid "41737f90-02d6-4036-8d60-5d5b6ccf939c" ;
+    sh:name "Rapportjaar" ;
+    sh:order 2201 ;
+    sh:path elod:financialYear ;
+    form:validations
+      [ a form:RequiredConstraint ;
+        form:grouping form:Bag ;
+        sh:path elod:financialYear ;
+        sh:resultMessage "Dit veld is verplicht."@nl
+      ],
+      [ a form:ValidYear ;
+        form:grouping form:MatchEvery ;
+        sh:path elod:financialYear ;
+        sh:resultMessage "Geef een geldig jaar op."@n ] ;
+    form:displayType displayTypes:defaultInput ;
+    sh:group fields:aDynamicPropertyGroup .
+
+fields:bffbea8d-e55b-4e3d-86e8-ba7aaee7863d a form:Field ;
+    mu:uuid "bffbea8d-e55b-4e3d-86e8-ba7aaee7863d" ;
+    sh:name "Welk beslissingsorgaan nam het besluit?" ;
+    sh:order 2000 ;
+    sh:path eli:passed_by ;
+    form:validations
+      [ a form:ConceptSchemeConstraint ; #TODO
+        form:grouping form:Bag ;
+        sh:path eli:passed_by ;
+        form:conceptScheme <http://data.lblod.info/concept-schemes/481c03f0-d07f-424e-9c2b-8d4cfb141c72> ;
+        sh:resultMessage "Selecteer een waarde uit de lijst."@nl
+      ],
+      [ a form:RequiredConstraint ;
+        form:grouping form:Bag ;
+        sh:resultMessage "Dit veld is verplicht."@nl;
+        sh:path eli:passed_by ] ;
+    form:options  """{"conceptScheme":"http://data.lblod.info/concept-schemes/481c03f0-d07f-424e-9c2b-8d4cfb141c72"}""" ;
+    form:displayType displayTypes:conceptSchemeSelector ;
+    sh:group fields:aDynamicPropertyGroup .
+
+# For notulen, we want another path that is semantically correct
+fields:e24d533f-3e63-4b36-a6af-21c65357e258 a form:Field ;
+    mu:uuid "e24d533f-3e63-4b36-a6af-21c65357e258" ;
+    sh:name "Welk beslissingsorgaan nam het besluit?" ;
+    sh:order 2000 ;
+    sh:path ( [ sh:inversePath besluit:heeftNotulen ] besluit:isGehoudenDoor ) ;
+    form:validations
+      [ a form:ConceptSchemeConstraint ; #TODO
+        form:grouping form:Bag ;
+        sh:path ( [ sh:inversePath besluit:heeftNotulen ] besluit:isGehoudenDoor ) ;
+        form:conceptScheme <http://data.lblod.info/concept-schemes/481c03f0-d07f-424e-9c2b-8d4cfb141c72> ;
+        sh:resultMessage "De waarde komt niet uit de opgegeven codelijst."@nl
+      ],
+      [ a form:RequiredConstraint ;
+        form:grouping form:Bag ;
+        sh:resultMessage "Dit veld is verplicht."@nl;
+        sh:path ( [ sh:inversePath besluit:heeftNotulen ] besluit:isGehoudenDoor )
+      ] ;
+    form:options  """{"conceptScheme":"http://data.lblod.info/concept-schemes/481c03f0-d07f-424e-9c2b-8d4cfb141c72"}""" ;
+    form:displayType displayTypes:conceptSchemeSelector ;
+    sh:group fields:aDynamicPropertyGroup .
+
+# custom bestuursorgaan-selector
+fields:4c7820f0-4011-4ab4-a16a-e128800e11bc a form:Field ;
+    mu:uuid "4c7820f0-4011-4ab4-a16a-e128800e11bc" ;
+    sh:name "Welk beslissingsorgaan nam het besluit?" ;
+    sh:order 2000 ;
+    sh:path eli:passed_by ;
+    form:validations
+      [ a form:ConceptSchemeConstraint ; #TODO
+        form:grouping form:Bag ;
+        sh:path eli:passed_by ;
+        form:conceptScheme <http://data.lblod.info/concept-schemes/481c03f0-d07f-424e-9c2b-8d4cfb141c72> ;
+        sh:resultMessage "Selecteer een waarde uit de lijst."@nl
+      ],
+      [ a form:RequiredConstraint ;
+        form:grouping form:Bag ;
+        sh:resultMessage "Dit veld is verplicht."@nl;
+        sh:path eli:passed_by ] ;
+    form:options  """{"conceptScheme":"http://data.lblod.info/concept-schemes/481c03f0-d07f-424e-9c2b-8d4cfb141c72"}""" ;
+    form:displayType displayTypes:bestuursorgaanSelector ; # notice this changed too
+    sh:group fields:aDynamicPropertyGroup .
+
+fields:303545a6-705b-43b3-86b7-b96436524be9 a form:Field ;
+    mu:uuid "303545a6-705b-43b3-86b7-b96436524be9" ;
+    sh:name "Bestuursorgaan classificatie code [hidden input]" ;
+    sh:order 1001 ;
+    sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:classificatie ) ;
+    sh:group fields:aDynamicPropertyGroup .
+
+fields:ac32a491-4b5c-4a7e-973f-fad6127c9433 a form:Field ;
+    mu:uuid "ac32a491-4b5c-4a7e-973f-fad6127c9433" ;
+    sh:name "Bestuurseenheid classificatie code [hidden input]" ;
+    sh:order 1001 ;
+    sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:bestuurt besluit:classificatie ) ;
+    sh:group fields:aDynamicPropertyGroup .
+
+fields:3dd6ed93-40f7-4d70-a6cb-f4de53dc8bfb a form:Field ;
+    mu:uuid "3dd6ed93-40f7-4d70-a6cb-f4de53dc8bfb" ;
+    sh:name "Datum zitting/besluit" ;
+    sh:order 2600 ;
+    sh:path ( [ sh:inversePath prov:generated ] dct:subject [ sh:inversePath besluit:behandelt ]  prov:startedAtTime ) ;  # see https://www.w3.org/TR/shacl/#property-paths for syntax
+    form:validations
+      [ a form:RequiredConstraint ;
+        form:grouping form:Bag ;
+        sh:resultMessage "Dit veld is verplicht.";
+        sh:path ( [ sh:inversePath prov:generated ] dct:subject [ sh:inversePath besluit:behandelt ]  prov:startedAtTime ) ],
+      [ a form:ValidDateTime ;
+        form:grouping form:MatchEvery ;
+        sh:path ( [ sh:inversePath prov:generated ] dct:subject [ sh:inversePath besluit:behandelt ]  prov:startedAtTime ) ;
+        sh:resultMessage "Geef een geldige datum en tijd op."] ;
+    form:displayType displayTypes:dateTime ;
+    sh:group fields:aDynamicPropertyGroup .
+
+fields:ba965704-5a74-4a77-b283-4f97f3b7ddbc a form:Field ;
+    mu:uuid "ba965704-5a74-4a77-b283-4f97f3b7ddbc" ;
+    sh:name "Datum zitting/besluitenlijst" ;
+    sh:order 2600 ;
+    sh:path ( [ sh:inversePath besluit:heeftBesluitenlijst ] prov:startedAtTime ) ;  # see https://www.w3.org/TR/shacl/#property-paths for syntax
+    form:validations
+      [ a form:RequiredConstraint ;
+        form:grouping form:Bag ;
+        sh:resultMessage "Dit veld is verplicht.";
+        sh:path ( [ sh:inversePath besluit:heeftBesluitenlijst ] prov:startedAtTime ) ],
+      [ a form:ValidDateTime ;
+        form:grouping form:MatchEvery ;
+        sh:path ( [ sh:inversePath besluit:heeftBesluitenlijst ] prov:startedAtTime ) ;
+        sh:resultMessage "Geef een geldige datum en tijd op."] ;
+    form:displayType displayTypes:dateTime ;
+    sh:group fields:aDynamicPropertyGroup .
+
+fields:857d670f-9a25-4555-bfe5-ecc48c2ffde3 a form:Field ;
+    mu:uuid "857d670f-9a25-4555-bfe5-ecc48c2ffde3" ;
+    sh:name "Datum zitting/notulen" ;
+    sh:order 2600 ;
+    sh:path ( [ sh:inversePath besluit:heeftNotulen ] prov:startedAtTime ) ;  # see https://www.w3.org/TR/shacl/#property-paths for syntax
+    form:validations
+      [ a form:RequiredConstraint ;
+        form:grouping form:Bag ;
+        sh:resultMessage "Dit veld is verplicht.";
+        sh:path ( [ sh:inversePath besluit:heeftNotulen ] prov:startedAtTime ) ],
+      [ a form:ValidDateTime ;
+        form:grouping form:MatchEvery ;
+        sh:path ( [ sh:inversePath besluit:heeftNotulen ] prov:startedAtTime ) ;
+        sh:resultMessage "Geef een geldige datum en tijd op."] ;
+    form:displayType displayTypes:dateTime ;
+    sh:group fields:aDynamicPropertyGroup .
+
+fields:720c86f8-4537-44b0-850b-fb3452d8bb2d a form:Field ;
+    mu:uuid "720c86f8-4537-44b0-850b-fb3452d8bb2d" ;
+    sh:name "Datum zitting/agenda" ;
+    sh:order 2600 ;
+    sh:path ( [ sh:inversePath besluit:heeftAgenda ] prov:startedAtTime ) ;  # see https://www.w3.org/TR/shacl/#property-paths for syntax
+    form:validations
+      [ a form:RequiredConstraint ;
+        form:grouping form:Bag ;
+        sh:resultMessage "Dit veld is verplicht.";
+        sh:path ( [ sh:inversePath besluit:heeftAgenda ] prov:startedAtTime ) ],
+      [ a form:ValidDateTime ;
+        form:grouping form:MatchEvery ;
+        sh:path ( [ sh:inversePath besluit:heeftAgenda ] prov:startedAtTime ) ;
+        sh:resultMessage "Geef een geldige datum en tijd op."] ;
+    form:displayType displayTypes:dateTime ;
+    sh:group fields:aDynamicPropertyGroup .
+
+fields:ef31b839-c461-4732-b35c-a8b6c7507cf1 a form:Field ;
+    mu:uuid "ef31b839-c461-4732-b35c-a8b6c7507cf1" ;
+    sh:name "MAR-code" ;
+    sh:order 5100 ;
+    sh:path lblodBesluit:chartOfAccount ;
+    form:validations
+      [ a form:ConceptSchemeConstraint ; #TODO
+        form:grouping form:Bag ;
+        sh:path lblodBesluit:chartOfAccount ;
+        form:conceptScheme  <http://lblod.data.gift/concept-schemes/b65b15ba-6755-4cd2-bd07-2c2cf3c0e4d3>;
+        sh:resultMessage "Selecteer een waarde uit de lijst."@nl
+      ] ;
+    form:options  """{"conceptScheme":"http://lblod.data.gift/concept-schemes/b65b15ba-6755-4cd2-bd07-2c2cf3c0e4d3"}""" ;
+    form:displayType displayTypes:conceptSchemeSelector ;
+    sh:group fields:aDynamicPropertyGroup .
+
+fields:a1b6c2e1-c1c3-45fb-84e7-cdd241a3130d a form:Field ;
+    mu:uuid "a1b6c2e1-c1c3-45fb-84e7-cdd241a3130d" ;
+    sh:name "MAR-code" ;
+    sh:order 5100 ;
+    sh:path lblodBesluit:chartOfAccount ;
+    form:validations
+      [ a form:RequiredConstraint ;
+        form:grouping form:Bag ;
+        sh:resultMessage "Dit veld is verplicht.";
+        sh:path lblodBesluit:chartOfAccount ],
+      [ a form:ConceptSchemeConstraint ; #TODO
+        form:grouping form:Bag ;
+        sh:path lblodBesluit:chartOfAccount ;
+        form:conceptScheme  <http://lblod.data.gift/concept-schemes/b65b15ba-6755-4cd2-bd07-2c2cf3c0e4d3>;
+        sh:resultMessage "Selecteer een waarde uit de lijst."@nl
+      ] ;
+    form:options  """{"conceptScheme":"http://lblod.data.gift/concept-schemes/b65b15ba-6755-4cd2-bd07-2c2cf3c0e4d3"}""" ;
+    form:displayType displayTypes:conceptSchemeSelector ;
+    sh:group fields:aDynamicPropertyGroup .
+
+fields:7793c27f-a41b-4665-a876-da9d94075a70 a form:Field ;
+    mu:uuid "7793c27f-a41b-4665-a876-da9d94075a70" ;
+    sh:name "Geldt vanaf" ;
+    sh:order 5101 ;
+    sh:path eli:first_date_entry_in_force ;
+    form:validations
+      [ a form:ValidDate ;
+        form:grouping form:MatchEvery ;
+        sh:path eli:first_date_entry_in_force ;
+        sh:resultMessage "Geef een geldige datum op."] ;
+    form:displayType displayTypes:date ;
+    sh:group fields:aDynamicPropertyGroup .
+
+fields:4b32c8fb-9725-4f9f-9872-b04198732483 a form:Field ;
+    mu:uuid "4b32c8fb-9725-4f9f-9872-b04198732483" ;
+    sh:name "Geldt vanaf" ;
+    sh:order 5101 ;
+    sh:path eli:first_date_entry_in_force ;
+    form:validations
+      [ a form:RequiredConstraint ;
+        form:grouping form:Bag ;
+        sh:path eli:first_date_entry_in_force ;
+        sh:resultMessage "Dit veld is verplicht."@nl
+      ],
+      [ a form:ValidDate ;
+        form:grouping form:MatchEvery ;
+        sh:path eli:first_date_entry_in_force ;
+        sh:resultMessage "Geef een geldige datum op."@nl ] ;
+    form:displayType displayTypes:date ;
+    sh:group fields:aDynamicPropertyGroup .
+
+fields:eeacea67-d327-4952-bbfa-31207823ba87 a form:Field ;
+    mu:uuid "eeacea67-d327-4952-bbfa-31207823ba87" ;
+    sh:name "Geldt tot" ;
+    sh:order 5102 ;
+    sh:path eli:date_no_longer_in_force ;
+    form:validations
+      [ a form:ValidDate ;
+        form:grouping form:MatchEvery ;
+        sh:path eli:date_no_longer_in_force ;
+        sh:resultMessage "Geef een geldige datum op."@nl ] ;
+    form:displayType displayTypes:date ;
+    sh:group fields:aDynamicPropertyGroup .
+
+fields:3a9f6f7d-2952-4128-84cc-bc8dc3d1ee44 a form:Field ;
+    mu:uuid "3a9f6f7d-2952-4128-84cc-bc8dc3d1ee44" ;
+    sh:name "Geldt tot" ;
+    sh:order 5102 ;
+    sh:path eli:date_no_longer_in_force ;
+    form:validations
+      [ a form:RequiredConstraint ;
+        form:grouping form:Bag ;
+        sh:path eli:date_no_longer_in_force ;
+        sh:resultMessage "Dit veld is verplicht."@nl
+      ],
+      [ a form:ValidDate ;
+        form:grouping form:MatchEvery ;
+        sh:path eli:date_no_longer_in_force ;
+        sh:resultMessage "Geef een geldige datum op."@nl] ;
+    form:displayType displayTypes:date ;
+    sh:group fields:aDynamicPropertyGroup .
+
+fields:7cd14dfd-81ff-4a5d-8374-5879c5877c4c a form:Field ;
+    mu:uuid "7cd14dfd-81ff-4a5d-8374-5879c5877c4c" ;
+    sh:name "Soort Belasting" ;
+    sh:order 5000 ;
+    sh:path rdf:type ;
+    form:validations
+    [ a form:RequiredConstraint ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        sh:resultMessage "Dit veld is verplicht."@nl
+    ],
+    [ a form:ConceptSchemeConstraint ; #TODO
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/3037c4f4-1c63-43ac-bfc4-b41d098b15a6>  ;
+        sh:resultMessage "Selecteer een waarde uit de lijst."@nl
+      ] ;
+    form:options  """{"conceptScheme":"http://lblod.data.gift/concept-schemes/3037c4f4-1c63-43ac-bfc4-b41d098b15a6"}""" ;
+    form:displayType displayTypes:conceptSchemeSelector ;
+    sh:group fields:aDynamicPropertyGroup .
+
+fields:49dbe1be-877a-4890-8465-1510ff18ce18 a form:Field ;
+    mu:uuid "49dbe1be-877a-4890-8465-1510ff18ce18" ;
+    sh:name "Datum van publicatie op webtoepassing" ;
+    sh:order 3700 ;
+    sh:path eli:date_publication ;
+    form:validations
+      [ a form:RequiredConstraint ;
+        form:grouping form:Bag ;
+        sh:resultMessage "Dit veld is verplicht.";
+        sh:path eli:date_publication ],
+      [ a form:ValidDate ;
+        form:grouping form:MatchEvery ;
+        sh:path eli:date_publication ;
+        sh:resultMessage "Geef een geldige datum op."@nl ] ;
+    form:displayType displayTypes:date ;
+    sh:group fields:aDynamicPropertyGroup .
+
+fields:e834ec56-2db3-43d8-8a54-baf6cc0463c6 a form:Field ;
+    mu:uuid "e834ec56-2db3-43d8-8a54-baf6cc0463c6" ;
+    sh:name "Type reglement/verordening" ;
+    sh:order 3800 ;
+    sh:path rdf:type ;
+    form:validations
+    [ a form:RequiredConstraint ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        sh:resultMessage "Dit veld is verplicht."@nl
+    ],
+    [ a form:ConceptSchemeConstraint ; #TODO
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/c93ccd41-aee7-488f-86d3-038de890d05a>  ;
+        sh:resultMessage "Selecteer een waarde uit de lijst."@nl
+      ] ;
+    form:options  """{"conceptScheme":"http://lblod.data.gift/concept-schemes/c93ccd41-aee7-488f-86d3-038de890d05a"}""" ;
+    form:displayType displayTypes:conceptSchemeSelector ;
+    sh:group fields:aDynamicPropertyGroup .
+
+##########################################################
+#  Files and links [First version]
+##########################################################
+
+##########################################################
+# Hidden field required for all variations of URL or FILE
+# input field which require validation.
+# It makes sure there is a type attached to hasPart object.
+# This enables correct validation in both front and backend.
+##########################################################
+fields:355fe001-cdca-48cc-8a6e-88b3aab09874 a form:Field ;
+    mu:uuid "355fe001-cdca-48cc-8a6e-88b3aab09874" ;
+    sh:name "Type RemoteDataObject or FileDataObject [hidden input]" ;
+    sh:order 10001 ;
+    sh:path ( dct:hasPart rdf:type );
+    sh:group fields:aDynamicPropertyGroup .
+
+##########################################################
+# Hidden field required for all variation of URL
+# input field which require validation.
+# This enables correct validation in both front and backend.
+##########################################################
+fields:d0052f0d-90bc-4543-a6b0-e90a1c1117db a form:Field ;
+    mu:uuid "d0052f0d-90bc-4543-a6b0-e90a1c1117db" ;
+    sh:name "RemoteDataObject/url [hidden input]" ;
+    sh:order 10001 ;
+    sh:path ( dct:hasPart nie:url );
+    form:validations
+     [ a form:UriConstraint ;
+        form:grouping form:MatchEvery ;
+        sh:resultMessage "Gelieve een geldige URL op te geven. Zorg dat vooraan in de link altijd http://, https://, ftp:// of sftp:// staat."; # TODO: later custom validator
+        sh:path ( dct:hasPart nie:url )
+     ];
+     sh:group fields:aDynamicPropertyGroup .
+
+##########################################################
+# Simple field for URL (required & valid URL)
+##########################################################
+fields:1e0f541f-61e9-43a7-bc5f-612eb44f52bb a form:Field ;
+    mu:uuid "1e0f541f-61e9-43a7-bc5f-612eb44f52bb" ;
+    sh:name "Links naar documenten" ;
+    sh:order 10000 ;
+    sh:path dct:hasPart;
+    form:validations
+     [ a form:UriConstraint ;
+        form:grouping form:MatchEvery ;
+        sh:resultMessage "Gelieve een geldige URL op te geven. Zorg dat vooraan in de link altijd http://, https://, ftp:// of sftp:// staat."; # TODO: later custom validator
+         sh:path ( dct:hasPart nie:url ) ],
+     [ a form:RequiredConstraint ;
+         form:grouping form:Bag ;
+         sh:path ( dct:hasPart nie:url ) ;
+         sh:resultMessage "Gelieve minstens één URL op te geven."@nl
+     ];
+    form:displayType <http://lblod.data.gift/display-types/remoteUrls/variation/1>;
+    sh:group fields:aDynamicPropertyGroup .
+
+##########################################################
+# Simple field for File (no validations)
+##########################################################
+fields:c7c5a589-0785-4032-a4bd-ee589add3c39 a form:Field ;
+    mu:uuid "c7c5a589-0785-4032-a4bd-ee589add3c39" ;
+    sh:name "Bestanden" ;
+    sh:order 10001 ;
+    sh:path dct:hasPart;
+    form:displayType <http://lblod.data.gift/display-types/files/variation/1> ;
+    sh:group fields:aDynamicPropertyGroup .
+
+##########################################################
+# Required file
+##########################################################
+fields:cd27f7a0-5e6b-4f76-b55c-a1cb7c4efee6 a form:Field ;
+    mu:uuid "cd27f7a0-5e6b-4f76-b55c-a1cb7c4efee6" ;
+    sh:name "Bestanden" ;
+    sh:order 10001 ;
+    sh:path dct:hasPart;
+    form:validations
+     [ a form:RequiredConstraint ;
+         form:grouping form:Bag ;
+         sh:path dct:hasPart ;
+         sh:resultMessage "Gelieve minstens één bestand op te geven."@nl
+     ];
+    form:displayType <http://lblod.data.gift/display-types/files> ;
+    sh:group fields:aDynamicPropertyGroup .
+
+##########################################################
+# Custom files and links fields
+# Following fields should be considered as a pair.
+# Their validation is mutually dependent.
+# Either a file or url should be present
+##########################################################
+
+fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b a form:Field ;
+    mu:uuid "c955d641-b9b3-4ec7-9838-c2a477c7e95b" ;
+    sh:name "Links naar documenten" ;
+    sh:order 10000 ;
+    sh:path dct:hasPart;
+    form:validations
+     [ a form:UriConstraint ;
+        form:grouping form:MatchEvery ;
+        sh:resultMessage "Gelieve een geldige URL op te geven. Zorg dat vooraan in de link altijd http://, https://, ftp:// of sftp:// staat."; # TODO: later custom validator
+         sh:path ( dct:hasPart nie:url ) ],
+     [ a form:RequiredConstraint ;
+         form:grouping form:Bag ;
+         sh:path dct:hasPart ;
+         sh:resultMessage "Gelieve minstens één URL of bestand op te geven."@nl
+     ];
+    form:displayType displayTypes:remoteUrls; # consider this v1.0
+    sh:group fields:aDynamicPropertyGroup .
+
+fields:c955d641-b9b3-4ec7-9838-c2a477c7e95a a form:Field ;
+    mu:uuid "c955d641-b9b3-4ec7-9838-c2a477c7e95a" ;
+    sh:name "Bestanden" ;
+    sh:order 10001 ;
+    sh:path dct:hasPart;
+    form:validations
+     [ a  form:RequiredConstraint ;
+          form:grouping form:Bag ;
+          sh:path dct:hasPart;
+          sh:resultMessage "Gelieve minstens één URL of bestand op te geven."@nl # TODO: later custom validator
+     ];
+    form:displayType displayTypes:files; # consider this v1.0
+    sh:group fields:aDynamicPropertyGroup .
+
+#####################################################################################################
+# File with custom helper text for "voorlopige aanleg, verplaatsing of wijzeging van een gemeenteweg"
+#####################################################################################################
+fields:f1fa5e64-1c68-4355-894a-2e0531f4412f a form:Field ;
+    mu:uuid "f1fa5e64-1c68-4355-894a-2e0531f4412f" ;
+    sh:name "Bestanden" ;
+    sh:order 10001 ;
+    sh:path dct:hasPart;
+    form:validations
+     [ a  form:RequiredConstraint ;
+          form:grouping form:Bag ;
+          sh:path dct:hasPart;
+          sh:resultMessage "Gelieve minstens één URL of bestand op te geven."@nl # TODO: later custom validator
+     ];
+    form:displayType displayTypes:files; # consider this v1.0
+    form:help """
+    <div class="au-c-content au-c-content--tiny">
+      <p>Volgende documenten moeten bezorgd worden: uittreksel uit de gemeenteraad met de voorlopige beslissing, ontwerp gemeentelijk rooilijnplan, gemeentelijk beleidskader (indien opgemaakt), gemeentelijk actieplan (indien opgemaakt).</p>
+      <p>
+        Het Departement MOW verleent momenteel enkel niet-dossierspecifiek advies. Het decreet Gemeentewegen kent nieuwe taken toe aan het Departement. Gezien de vrij recente goedkeuring van dit decreet en de mogelijke impact op de organisatie loopt de transitie die gepaard gaat met het opnemen van deze taken momenteel nog.
+        We willen benadrukken dat uw beslissing moet voldoen aan de doelstellingen en principes zoals geformuleerd in artikel 3 en 4 van het decreet Gemeentewegen:
+      </p>
+      <ul>
+        <li>het belang van de huidige en toekomstige behoeften van de zachte mobiliteit staat voorop.</li>
+        <li>de noodzaak om een geïntegreerd beleid te voeren, dat leidt tot de uitbouw van veilige wegen op lokaal niveau en op de herwaardering en bescherming van de trage wegen.</li>
+      </ul>
+      <p>
+        Eventuele wijzigingen van het gemeentelijk wegennet moeten dan ook altijd van algemeen belang zijn, waarbij wijzigingen en afschaffingen uitzonderingsmaatregelen zijn. Het is ook van belang om de wijzigingen te bekijken in een ruimere context dan enkel het eigen gemeentelijk niveau. Verder vragen we u de vormvereisten van het decreet Gemeentewegen na te leven, oog te hebben voor de eventuele meer- en minwaarden die het dossier met zich kan meebrengen en het goede huisvader-principe niet te verwaarlozen.
+      </p>
+    </div>""" ;
+    sh:group fields:aDynamicPropertyGroup .
+
+#########################################################
+# File with custom helper text for "voorlopige opheffing"
+#########################################################
+fields:6f7cb360-26df-4233-988a-a11ac9c33ba4 a form:Field ;
+    mu:uuid "6f7cb360-26df-4233-988a-a11ac9c33ba4" ;
+    sh:name "Bestanden" ;
+    sh:order 10001 ;
+    sh:path dct:hasPart;
+    form:validations
+     [ a  form:RequiredConstraint ;
+          form:grouping form:Bag ;
+          sh:path dct:hasPart;
+          sh:resultMessage "Gelieve minstens één URL of bestand op te geven."@nl # TODO: later custom validator
+     ];
+    form:displayType displayTypes:files; # consider this v1.0
+    form:help """
+    <div class="au-c-content au-c-content--tiny">
+      <p>Volgende documenten moeten bezorgd worden: uittreksel uit de gemeenteraad met de voorlopige beslissing, ontwerp grafisch plan, gemeentelijk beleidskader (indien opgemaakt), gemeentelijk actieplan (indien opgemaakt).</p>
+      <p>
+        Het Departement MOW verleent momenteel enkel niet-dossierspecifiek advies. Het decreet Gemeentewegen kent nieuwe taken toe aan het Departement. Gezien de vrij recente goedkeuring van dit decreet en de mogelijke impact op de organisatie loopt de transitie die gepaard gaat met het opnemen van deze taken momenteel nog.
+        We willen benadrukken dat uw beslissing moet voldoen aan de doelstellingen en principes zoals geformuleerd in artikel 3 en 4 van het decreet Gemeentewegen:
+      </p>
+      <ul>
+        <li>het belang van de huidige en toekomstige behoeften van de zachte mobiliteit staat voorop.</li>
+        <li>de noodzaak om een geïntegreerd beleid te voeren, dat leidt tot de uitbouw van veilige wegen op lokaal niveau en op de herwaardering en bescherming van de trage wegen.</li>
+      </ul>
+      <p>
+        Eventuele wijzigingen van het gemeentelijk wegennet moeten dan ook altijd van algemeen belang zijn, waarbij wijzigingen en afschaffingen uitzonderingsmaatregelen zijn. Het is ook van belang om de wijzigingen te bekijken in een ruimere context dan enkel het eigen gemeentelijk niveau. Verder vragen we u de vormvereisten van het decreet Gemeentewegen na te leven, oog te hebben voor de eventuele meer- en minwaarden die het dossier met zich kan meebrengen en het goede huisvader-principe niet te verwaarlozen.
+      </p>
+    </div>""" ;
+    sh:group fields:aDynamicPropertyGroup .
+
+######################################################################################################
+# File with custom helper text for "definitieve aanleg, verplaatsing of wijzeging van een gemeenteweg"
+######################################################################################################
+fields:43c48290-8cc0-4066-aeee-8545bca7c68d a form:Field ;
+    mu:uuid "43c48290-8cc0-4066-aeee-8545bca7c68d" ;
+    sh:name "Bestanden" ;
+    sh:order 10001 ;
+    sh:path dct:hasPart;
+    form:validations
+     [ a  form:RequiredConstraint ;
+          form:grouping form:Bag ;
+          sh:path dct:hasPart;
+          sh:resultMessage "Gelieve minstens één URL of bestand op te geven."@nl # TODO: later custom validator
+     ];
+    form:displayType displayTypes:files; # consider this v1.0
+    form:help """Volgende documenten moeten bezorgd worden: uittreksel uit de gemeenteraad met de definitieve beslissing, gemeentelijk rooilijnplan, gemeentelijk beleidskader (indien opgemaakt), gemeentelijk actieplan (indien opgemaakt)""" ;
+    sh:group fields:aDynamicPropertyGroup .
+
+#########################################################
+# File with custom helper text for "definitive opheffing"
+#########################################################
+fields:2aecc67c-687d-448c-be01-94ad42fb51c1 a form:Field ;
+    mu:uuid "2aecc67c-687d-448c-be01-94ad42fb51c1" ;
+    sh:name "Bestanden" ;
+    sh:order 10001 ;
+    sh:path dct:hasPart;
+    form:validations
+     [ a  form:RequiredConstraint ;
+          form:grouping form:Bag ;
+          sh:path dct:hasPart;
+          sh:resultMessage "Gelieve minstens één URL of bestand op te geven."@nl # TODO: later custom validator
+     ];
+    form:displayType displayTypes:files; # consider this v1.0
+    form:help """Volgende documenten moeten bezorgd worden: uittreksel uit de gemeenteraad met de definitieve beslissing, grafisch plan, gemeentelijk beleidskader (indien opgemaakt), gemeentelijk actieplan (indien opgemaakt)""" ;
+    sh:group fields:aDynamicPropertyGroup .
+
+#########################################################
+# File with custom helper text for "Budget"
+#########################################################
+fields:7465c000-c844-4ba9-82cc-bd173cbe41a3 a form:Field ;
+    mu:uuid "7465c000-c844-4ba9-82cc-bd173cbe41a3" ;
+    sh:name "Bestanden" ;
+    sh:order 10001 ;
+    sh:path dct:hasPart;
+    form:validations
+     [ a  form:RequiredConstraint ;
+          form:grouping form:Bag ;
+          sh:path dct:hasPart;
+          sh:resultMessage "Gelieve minstens één URL of bestand op te geven."@nl # TODO: later custom validator
+     ];
+    form:displayType displayTypes:files; # consider this v1.0
+    form:help """Voeg hier budget en beleidsnota toe.""" ;
+    sh:group fields:aDynamicPropertyGroup .
+
+#########################################################
+# File with custom helper text for "Meerjarenplan(aanpassing)"
+#########################################################
+fields:95c9236e-e849-4888-82ae-b812f906e75d a form:Field ;
+    mu:uuid "95c9236e-e849-4888-82ae-b812f906e75d" ;
+    sh:name "Bestanden" ;
+    sh:order 10001 ;
+    sh:path dct:hasPart;
+    form:validations
+     [ a  form:RequiredConstraint ;
+          form:grouping form:Bag ;
+          sh:path dct:hasPart;
+          sh:resultMessage "Gelieve minstens één URL of bestand op te geven."@nl # TODO: later custom validator
+     ];
+    form:displayType displayTypes:files; # consider this v1.0
+    form:help """Voeg hier volgende bijlagen toe: meerjarenplan, strategische nota, individuele afsprakennota.""" ;
+    sh:group fields:aDynamicPropertyGroup .
+
+
+
+#########################################################
+# File with custom helper text for "Jaarrekening"
+#########################################################
+fields:d0555b84-9d8c-4ca8-b7f2-a3bee96bd82f a form:Field ;
+    mu:uuid "d0555b84-9d8c-4ca8-b7f2-a3bee96bd82f" ;
+    sh:name "Bestanden" ;
+    sh:order 10001 ;
+    sh:path dct:hasPart;
+    form:validations
+     [ a  form:RequiredConstraint ;
+          form:grouping form:Bag ;
+          sh:path dct:hasPart;
+          sh:resultMessage "Gelieve minstens één URL of bestand op te geven."@nl # TODO: later custom validator
+     ];
+    form:displayType displayTypes:files; # consider this v1.0
+    form:help """Voeg hier jaarrekening, uittreksel werkingsrekening en patrimoniumrekeningen en eventueel aanvullende nota toe.""" ;
+    sh:group fields:aDynamicPropertyGroup .
+
+#########################################################
+# File with custom helper text for "Eindrekening"
+#########################################################
+fields:e5aa62e8-08b7-4216-8b9c-5fea766e9a22 a form:Field ;
+    mu:uuid "e5aa62e8-08b7-4216-8b9c-5fea766e9a22" ;
+    sh:name "Bestanden" ;
+    sh:order 10001 ;
+    sh:path dct:hasPart;
+    form:validations
+     [ a  form:RequiredConstraint ;
+          form:grouping form:Bag ;
+          sh:path dct:hasPart;
+          sh:resultMessage "Gelieve minstens één URL of bestand op te geven."@nl # TODO: later custom validator
+     ];
+    form:displayType displayTypes:files; # consider this v1.0
+    form:help """Voeg hier eindrekening, uittreksel werkingsrekening en patrimoniumrekeningen en eventueel aanvullende nota toe.""" ;
+    sh:group fields:aDynamicPropertyGroup .
+
+
+
+#########################################################
+# File with custom helper text for "Budget" for centrale besturen eredienst
+#########################################################
+fields:9dd53fc5-077b-439c-aad9-5530f95083e8 a form:Field ;
+    mu:uuid "9dd53fc5-077b-439c-aad9-5530f95083e8" ;
+    sh:name "Bestanden" ;
+    sh:order 10001 ;
+    sh:path dct:hasPart;
+    form:validations
+     [ a  form:RequiredConstraint ;
+          form:grouping form:Bag ;
+          sh:path dct:hasPart;
+          sh:resultMessage "Gelieve minstens één URL of bestand op te geven."@nl # TODO: later custom validator
+     ];
+    form:displayType displayTypes:files; # consider this v1.0
+    form:help """Voeg hier een overzicht en alle  budgetten en bijhorende beleidsnota's toe.""" ;
+    sh:group fields:aDynamicPropertyGroup .
+
+
+#########################################################
+# File with custom helper text for "Meerjarenplannen" voor centrale besturen eredienst 
+#########################################################
+fields:c34a860a-a82e-482d-b077-6482a4edfe3f a form:Field ;
+    mu:uuid "c34a860a-a82e-482d-b077-6482a4edfe3f" ;
+    sh:name "Bestanden" ;
+    sh:order 10001 ;
+    sh:path dct:hasPart;
+    form:validations
+     [ a  form:RequiredConstraint ;
+          form:grouping form:Bag ;
+          sh:path dct:hasPart;
+          sh:resultMessage "Gelieve minstens één URL of bestand op te geven."@nl # TODO: later custom validator
+     ];
+    form:displayType displayTypes:files; # consider this v1.0
+    form:help """Voeg hier een overzicht en alle meerjarenplanpen, strategische nota's en afsprakennota's toe.""" ;
+    sh:group fields:aDynamicPropertyGroup .
+
+
+#########################################################
+# File with custom helper text for "Jaarrekeningen-centraal-bestuur-eredienst"
+#########################################################
+fields:48cff9eb-579b-4e6e-958f-6229903c63d8 a form:Field ;
+    mu:uuid "48cff9eb-579b-4e6e-958f-6229903c63d8" ;
+    sh:name "Bestanden" ;
+    sh:order 10001 ;
+    sh:path dct:hasPart;
+    form:validations
+     [ a  form:RequiredConstraint ;
+          form:grouping form:Bag ;
+          sh:path dct:hasPart;
+          sh:resultMessage "Gelieve minstens één URL of bestand op te geven."@nl # TODO: later custom validator
+     ];
+    form:displayType displayTypes:files; # consider this v1.0
+    form:help """Voeg hier een toelagenoverzicht en alle jaarrekeningen, uittreksels werkingsrekening en patrimoniumrekeningen en eventueel aanvullende nota's toe.""" ;
+    sh:group fields:aDynamicPropertyGroup .
+
+#########################################################
+# File with custom helper text for "Besluit handhaven"
+#########################################################
+fields:1b0b0d89-cb84-45d9-ba07-3a067df84ccc a form:Field ;
+    mu:uuid "1b0b0d89-cb84-45d9-ba07-3a067df84ccc" ;
+    sh:name "Bestanden" ;
+    sh:order 10001 ;
+    sh:path dct:hasPart;
+    form:validations
+     [ a  form:RequiredConstraint ;
+          form:grouping form:Bag ;
+          sh:path dct:hasPart;
+          sh:resultMessage "Gelieve minstens één URL of bestand op te geven."@nl # TODO: later custom validator
+     ];
+    form:displayType displayTypes:files; # consider this v1.0
+    form:help """Voeg hier een handhavingsbesluit toe.""" ;
+    sh:group fields:aDynamicPropertyGroup .
+
+
+##########################################################
+# End Custom files and links fields
+##########################################################
+
+##########################################################
+# Alert for Besluit handhaven na ontvangst schorsingsbesluit
+##########################################################
+fields:2ab610ad-871b-443e-9b79-3723390ba0c0 a form:Field;
+    mu:uuid "2ab610ad-871b-443e-9b79-3723390ba0c0" ;
+    sh:name "Met dit formulier kan je een besluit van het bestuur handhaven, na ontvangst van het schorsingsbesluit van de provinciegouverneur of de toezichthoudende gemeente of provincie.";
+    sh:order 101;
+    form:options """{ "skin": "warning", "icon": "alert-triangle", "size": "small", "closable": false }""";
+    form:displayType displayTypes:alert ;
+    sh:group fields:aDynamicPropertyGroup .
+
+##########################################################
+# Custom Fields for LEKP
+##########################################################
+
+#### Infolabel ####
+fields:2bb6c63d-2cb7-4e82-839f-5c1e0a4f6a5e a form:Field;
+    mu:uuid "2bb6c63d-2cb7-4e82-839f-5c1e0a4f6a5e" ;
+    sh:name "Dit dossierstype heeft betrekking tot het Lokaal Energie- en Klimaatpact.";
+    form:help """
+    <a href="https://lokaalklimaatpact.be/formulieren.html" target="_blank">Meer informatie daarover, alsook over dit formulier, kun je hier terugvinden. </a>
+    """ ;
+    sh:order 101;
+    form:options """{ "level": "6", "skin": "6"}""";
+    form:displayType displayTypes:heading ;
+    sh:group fields:aDynamicPropertyGroup .
+
+#### Authentieke bron ####
+fields:7ebdf368-fe63-45d7-9d44-030ec0cd9ab9 a form:Field ;
+    mu:uuid "7ebdf368-fe63-45d7-9d44-030ec0cd9ab9" ;
+    sh:name "Authentieke bron" ;
+    form:help """
+    Correcties voor <a href="https://groenblauwpeil.be/" target="_blank">groenblauwpeil</a>
+     en <a href="/subsidy/applications" target="_blank">het Loket voor Lokale Besturen (module subsidie)</a> kunnen rechtstreeks in de authentieke bron.
+    """;
+    sh:order 102 ;
+    sh:path lblodBesluit:LEKPAuthenticSource ;
+    form:validations
+      [ a form:RequiredConstraint ;
+        form:grouping form:Bag ;
+        sh:path lblodBesluit:LEKPAuthenticSource ;
+        sh:resultMessage "Dit veld is verplicht."@nl
+      ];
+    form:options  """{"conceptScheme":"http://lblod.data.gift/concept-schemes/c2e7699a-b543-443c-b8b2-b60bef8767dc", "orderBy": "http://purl.org/linked-data/cube#order"}""" ;
+    form:displayType displayTypes:conceptSchemeSelector ;
+    sh:group fields:aDynamicPropertyGroup .
+
+  #### Type Correctie ####
+  fields:40c91f8e-be26-4e7d-8920-ae547f143744 a form:Field ;
+    mu:uuid "40c91f8e-be26-4e7d-8920-ae547f143744" ;
+    sh:name "Type Correctie" ;
+    form:help """1 type correctie per melding - binnen eenzelfde type correctie kunnen meerdere datacorrecties doorgegeven worden.""";
+    sh:order 103 ;
+    sh:path lblodBesluit:LEKPCorrectionType ;
+    form:validations
+      [ a form:RequiredConstraint ;
+        form:grouping form:Bag ;
+        sh:path lblodBesluit:LEKPCorrectionType ;
+        sh:resultMessage "Dit veld is verplicht."@nl
+      ];
+    form:options  """{"conceptScheme":"http://lblod.data.gift/concept-schemes/1dfc51af-99fd-4be9-a681-41360c195f14"}""" ;
+    form:displayType displayTypes:conceptSchemeSelector ;
+    sh:group fields:aDynamicPropertyGroup .
+
+
+
+#### Doelstelling ####
+fields:b2813526-d400-4cba-bdc4-bf64b2e21a80 a form:Field ;
+    mu:uuid "b2813526-d400-4cba-bdc4-bf64b2e21a80" ;
+    sh:name "LEKP-doelstelling" ;
+    sh:order 102 ;
+    sh:path lblodBesluit:LEKPGoal ;
+    form:validations
+      [ a form:RequiredConstraint ;
+        form:grouping form:Bag ;
+        sh:path lblodBesluit:LEKPGoal ;
+        sh:resultMessage "Dit veld is verplicht."@nl
+      ];
+    form:options  """{"conceptScheme":"http://lblod.data.gift/concept-schemes/5d05a003-4692-4aff-9e93-325db2aefb8a"}""" ;
+    form:displayType displayTypes:conceptSchemeSelector ;
+    sh:group fields:aDynamicPropertyGroup .
+
+  #### Type Toelichting ####
+  fields:746e3820-c8db-478b-85d0-d238c6a531ea a form:Field ;
+    mu:uuid "746e3820-c8db-478b-85d0-d238c6a531ea" ;
+    sh:name "Type Toelichting" ;
+    sh:order 103 ;
+    sh:path lblodBesluit:LEKPExplanationType ;
+    form:validations
+      [ a form:RequiredConstraint ;
+        form:grouping form:Bag ;
+        sh:path lblodBesluit:LEKPExplanationType ;
+        sh:resultMessage "Dit veld is verplicht."@nl
+      ];
+    form:options  """{"conceptScheme":"http://lblod.data.gift/concept-schemes/0b93ef1c-4435-4922-8611-31b4f3ca3c85"}""" ;
+    form:displayType displayTypes:conceptSchemeSelector ;
+    sh:group fields:aDynamicPropertyGroup.
+
+  #### Omschrijving ####
+  fields:5a52adff-2558-437e-8a30-132648f4870c a form:Field ;
+    mu:uuid "5a52adff-2558-437e-8a30-132648f4870c";
+    sh:name "Omschrijving" ;
+    form:help """
+    Voeg hier uw beschrijving van de gevraagde correctie in. ABB volgt deze correctie verder op. <br>
+    <br> Een voorbeeld van aanvulling: <br>
+    In 2021 heeft het bestuur 20 laadpunten geïnstalleerd. Deze ontbreken in de cijfers. Details van de
+    laadpalen vind je in de bijlage bij dit formulier.
+    """;
+    sh:order 104 ;
+    sh:path lblodBesluit:LEKPDescription ;
+    form:options """{}""" ;
+    form:displayType displayTypes:textArea ;
+    form:validations
+    [ a form:MaxLength ;
+      form:grouping form:MatchEvery ;
+      form:max "500" ;
+      sh:resultMessage "Max. karakters overschreden." ;
+      sh:path lblodBesluit:LEKPDescription ],
+    [ a form:RequiredConstraint ;
+      form:grouping form:Bag ;
+      sh:resultMessage "Dit veld is verplicht." ;
+      sh:path lblodBesluit:LEKPDescription ] ;
+    sh:group fields:aDynamicPropertyGroup.
+
+  #### Toelichting ####
+  fields:8b8c8dc0-a728-42c6-837a-3b625d219140 a form:Field ;
+    mu:uuid "8b8c8dc0-a728-42c6-837a-3b625d219140";
+    sh:name "Toelichting" ;
+    form:help """Voeg hierboven uw toelichting in. Enkel de laatst doorgestuurde versie verschijnt in het LEKP-rapport bij de volgende maandelijkse update. <br> <br>
+    3 voorbeelden: <br>
+    <ul  style="list-style-type:disc; margin-left: 30px;">
+      <li>In het verleden heeft het bestuur besloten om een ander beleid uit te voeren, zie het besluit van ...</li>
+      <li>Wegens plaatsgebrek heeft het bestuur besloten om samen te werken met een ander bestuur.
+      Hierdoor zullen de door ons aangeplante bomen niet op ons grondgebied staan. Meer informatie hierover op ...</li>
+      <li>Het bestuur besloot in 2008 om maximaal in te zetten op het openbaar vervoer. Dit krijgt hierdoor prioriteit op autodeelsystemen.
+      Meer informatie hierover vind je op onze website op ...</li>
+  </ul>
+    """;
+    sh:order 104 ;
+    sh:path lblodBesluit:LEKPClarification ;
+    form:options """{}""" ;
+    form:displayType displayTypes:textArea ;
+    form:validations
+    [ a form:MaxLength ;
+      form:grouping form:MatchEvery ;
+      form:max "500" ;
+      sh:resultMessage "Max. karakters overschreden." ;
+      sh:path lblodBesluit:LEKPClarification ],
+    [ a form:RequiredConstraint ;
+      form:grouping form:Bag ;
+      sh:resultMessage "Dit veld is verplicht." ;
+      sh:path lblodBesluit:LEKPClarification ] ;
+    sh:group fields:aDynamicPropertyGroup.
+
+ #### Meer info ####
+  fields:fa96567b-6677-4502-add5-f41e24dfee15 a form:Field ;
+    mu:uuid "fa96567b-6677-4502-add5-f41e24dfee15";
+    sh:name "Meer info" ;
+    form:help """Voeg hier eventueel een URL toe met een meer uitgebreide toelichting.""";
+    form:validations
+     [ a form:UriConstraint ;
+       form:grouping form:MatchEvery ;
+       sh:resultMessage "Gelieve een geldige URL op te geven. Zorg dat vooraan in de link altijd http://, https://, ftp:// of sftp:// staat.";
+       sh:path rdfs:seeAlso
+      ];
+    sh:order 105 ;
+    sh:path rdfs:seeAlso ;
+    form:options """{}""" ;
+    form:displayType displayTypes:defaultInput ;
+    sh:group fields:aDynamicPropertyGroup .
+
+#### Bestanden ####
+fields:f7e4b0a8-e970-4d49-a6d0-16c99a761f17 a form:Field ;
+    mu:uuid "f7e4b0a8-e970-4d49-a6d0-16c99a761f17" ;
+    sh:name "Bestanden" ;
+    form:help """Hier kan je bijkomende informatie toevoegen (uitgebreide omschrijving, screenshots, data...)""";
+    sh:order 105 ;
+    sh:path dct:hasPart;
+    form:displayType <http://lblod.data.gift/display-types/files/variation/1> ;
+    sh:group fields:aDynamicPropertyGroup.
+
+
+#### Datum Klimaattafel ####
+fields:2bc38df5-dc28-4d4d-a6e1-b6d95644c8d7 a form:Field ;
+    mu:uuid "2bc38df5-dc28-4d4d-a6e1-b6d95644c8d7";
+    sh:name "Datum klimaattafel" ;
+    sh:order 102 ;
+    sh:path lblodBesluit:LEKPClimateTableDate ;
+    form:options """{}""" ;
+    form:displayType displayTypes:date ;
+    form:validations
+    [ a form:RequiredConstraint ;
+      form:grouping form:Bag ;
+      sh:resultMessage "Dit veld is verplicht." ;
+      sh:path lblodBesluit:LEKPClimateTableDate ],
+    [ a form:ValidDate ;
+      form:grouping form:MatchEvery ;
+      sh:resultMessage "Geef een geldige datum op." ;
+      sh:path lblodBesluit:LEKPClimateTableDate ] ;
+    sh:group fields:aDynamicPropertyGroup .
+
+#### Households ####
+fields:28ddce67-6aaf-4a3b-8953-63eeb7178d1f a form:Field ;
+    mu:uuid "28ddce67-6aaf-4a3b-8953-63eeb7178d1f";
+    sh:name "Geef hier aan hoeveel huishoudens uitgenodigd zijn voor een klimaattafel voor 31/12/2024" ;
+    sh:order 103 ;
+    sh:path lblodBesluit:LEKPHouseholds ;
+    form:options """{}""" ;
+    form:displayType displayTypes:numericalInput ;
+    form:validations
+    [ a form:RequiredConstraint ;
+      form:grouping form:Bag ;
+      sh:resultMessage "Dit veld is verplicht." ;
+      sh:path lblodBesluit:LEKPHouseholds ],
+    [ a form:ValidInteger ;
+      form:grouping form:MatchEvery ;
+      sh:resultMessage "Aantal moet een een geheel getal zijn." ;
+      sh:path lblodBesluit:LEKPHouseholds ],
+    [ a form:PositiveNumber ;
+      form:grouping form:MatchEvery ;
+      sh:resultMessage "Geef een positief aantal op." ;
+      sh:path lblodBesluit:LEKPHouseholds ] ;
+    sh:group fields:aDynamicPropertyGroup .
+
+#### Links ####  
+fields:df63b483-f2ee-4274-a7d0-0cfc916d22ce a form:Field ;
+    mu:uuid "df63b483-f2ee-4274-a7d0-0cfc916d22ce" ;
+    sh:name "Voeg hier een link toe naar een webpagina, document of persbericht waar er meer informatie staat over de organisatie van de klimaattafel" ;
+    sh:order 104 ;
+    sh:path dct:hasPart;
+    form:validations
+     [ a form:UriConstraint ;
+        form:grouping form:MatchEvery ;
+        sh:resultMessage "Gelieve een geldige URL op te geven. Zorg dat vooraan in de link altijd http://, https://, ftp:// of sftp:// staat."; # TODO: later custom validator
+         sh:path ( dct:hasPart nie:url ) ],
+     [ a form:RequiredConstraint ;
+         form:grouping form:Bag ;
+         sh:path ( dct:hasPart nie:url ) ;
+         sh:resultMessage "Gelieve minstens één URL op te geven."@nl
+     ];
+    form:displayType <http://lblod.data.gift/display-types/remoteUrls/variation/1>;
+    sh:group fields:aDynamicPropertyGroup .
+
+##########################################################
+# Custom Fields for Erediensten/representatieve organen
+##########################################################
+
+#### Link label ####
+fields:9724f76e-6b1d-480d-a868-f24b74f236a0 a form:Field;
+    mu:uuid "9724f76e-6b1d-480d-a868-f24b74f236a0" ;
+    sh:name "Dit dossierstype heeft betrekking tot erkenning lokale geloofsgemeenschappen.";
+    form:help """
+    <a href="https://abb-vlaanderen.gitbook.io/handleiding-loket/erediensten/faq/eredienstendossiers-voor-representatieve-organen" target="_blank">Meer informatie daarover, alsook het aanvraagformulier, kun je hier terugvinden. </a>
+    """ ;
+    sh:order 101;
+    form:options """{ "level": "6", "skin": "6"}""";
+    form:displayType displayTypes:heading ;
+    sh:group fields:aDynamicPropertyGroup .
+
+
+##########################################################
+# Custom Fields for Erediensten selector (FILTERED)
+# Centrale besturen and besturen van eredienst
+##########################################################
+fields:7d0a105f-0c7e-49ab-9ab8-68d5381b3b8b a form:Field ;
+    mu:uuid "7d0a105f-0c7e-49ab-9ab8-68d5381b3b8b" ;
+    sh:name "Betreffend (centraal) bestuur van de eredienst" ;
+    sh:order 101 ;
+    sh:path eli:is_about ;
+    form:validations
+      [ a form:RequiredConstraint ;
+        form:grouping form:Bag ;
+        sh:path eli:is_about ;
+        sh:resultMessage "Dit veld is verplicht."@nl
+      ],
+      [ a form:ConceptSchemeConstraint ;
+        form:grouping form:Bag ;
+        sh:path eli:is_about ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/362a6a78-6431-4d0a-b20d-22f1faca4130> ;
+        sh:resultMessage "Selecteer een waarde uit de lijst."@nl
+      ] ;
+    form:options  """{"conceptScheme":"http://lblod.data.gift/concept-schemes/362a6a78-6431-4d0a-b20d-22f1faca4130"}""" ;
+    form:displayType displayTypes:conceptSchemeSelector ;
+    sh:group fields:aDynamicPropertyGroup .
+
+##########################################################
+# Custom Fields for Erediensten selector (FILTERED)
+# only besturen van eredienst
+##########################################################
+fields:00a7bce6-2925-4794-93cb-ebd571b28831 a form:Field ;
+    mu:uuid "00a7bce6-2925-4794-93cb-ebd571b28831" ;
+    sh:name "Betreffend bestuur van de eredienst" ;
+    sh:order 101 ;
+    sh:path eli:is_about ;
+    form:validations
+      [ a form:RequiredConstraint ;
+        form:grouping form:Bag ;
+        sh:path eli:is_about ;
+        sh:resultMessage "Dit veld is verplicht."@nl
+      ],
+      [ a form:ConceptSchemeConstraint ;
+        form:grouping form:Bag ;
+        sh:path eli:is_about ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/2e136902-f709-4bf7-a54a-9fc820cf9f07> ;
+        sh:resultMessage "Selecteer een waarde uit de lijst."@nl
+      ] ;
+    form:options  """{"conceptScheme":"http://lblod.data.gift/concept-schemes/2e136902-f709-4bf7-a54a-9fc820cf9f07"}""" ;
+    form:displayType displayTypes:conceptSchemeSelector ;
+    sh:group fields:aDynamicPropertyGroup .
+
+##########################################################
+# Custom Fields for Erediensten selector RO (FILTERED)
+##########################################################
+fields:eb089ca1-2c5b-42a4-a781-f009c46ac583 a form:Field ;
+    mu:uuid "eb089ca1-2c5b-42a4-a781-f009c46ac583" ;
+    sh:name "Betreffend bestuur van de eredienst" ;
+    sh:order 101 ;
+    sh:path eli:is_about ;
+    form:validations
+      [ a form:RequiredConstraint ;
+        form:grouping form:Bag ;
+        sh:path eli:is_about ;
+        sh:resultMessage "Dit veld is verplicht."@nl
+      ],
+      [ a form:ConceptSchemeConstraint ;
+        form:grouping form:Bag ;
+        sh:path eli:is_about ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/164a27d5-cf7e-43ea-996b-21645c02a920> ;
+        sh:resultMessage "Selecteer een waarde uit de lijst."@nl
+      ] ;
+    form:options  """{"conceptScheme":"http://lblod.data.gift/concept-schemes/164a27d5-cf7e-43ea-996b-21645c02a920"}""" ;
+    form:displayType displayTypes:conceptSchemeSelector ;
+    sh:group fields:aDynamicPropertyGroup .
+
+
+
+##########################################################
+#  Files and links  [First version]
+##########################################################
+
+##########################################################
+#  VLABEL [First version]
+# It is a bit of the odity this set of fields.
+# There is no 1:1 relation between components in the frontend
+# and the required fields of VLABEL.
+# This is because it is relatively complex from UI-perspective
+# This is why we group all validations under field "Opcentiem"
+# as this will handle and display errors to the user.
+# The hidden input fields are still part of the form and are used
+# to extract information from the form.
+##########################################################
+fields:1ee5132e-28c0-4292-9fe6-24c7be456580 a form:Field ;
+    mu:uuid "1ee5132e-28c0-4292-9fe6-24c7be456580" ;
+    sh:name "Opcentiem" ;
+    sh:order 5001 ;
+    sh:path ( lblodBesluit:taxRate schema:price );
+    form:validations [
+      a form:VlabelExtraTaxRateOrAmountConstraint ;
+      form:grouping form:Bag ;
+      sh:path lblodBesluit:taxRate;
+      sh:resultMessage "Differentiatie en bedrag opcentiem kunnen niet tegelijk ingevuld worden."
+    ],
+    [ a form:ValidBoolean ;
+        form:grouping form:MatchEvery ;
+        sh:path lblodBesluit:hasAdditionalTaxRate ;
+        sh:resultMessage "Geen geldige waarde voor differentiatie."@nl
+    ],
+    [ a form:VlabelSingleInstanceTaxRateOrExtraTaxRate ;
+        form:grouping form:Bag ;
+        sh:path lblodBesluit:hasAdditionalTaxRate ;
+        sh:resultMessage "Slechts één waarde voor differentiatie wordt aanvaard."@nl
+    ],
+    [ a form:VlabelSingleInstanceTaxRateOrExtraTaxRate ;
+        form:grouping form:Bag ;
+        sh:path lblodBesluit:taxRate ;
+        sh:resultMessage "Slechts één instantie van opcentiem wordt aanvaard"@nl
+    ];
+    form:displayType displayTypes:vLabelOpcentiem ;
+    sh:group fields:aDynamicPropertyGroup .
+
+fields:f3c1f62e-0fc6-4440-8208-7a0ef49fb28c a form:Field ;
+    mu:uuid "f3c1f62e-0fc6-4440-8208-7a0ef49fb28c" ;
+    sh:name "Differentiatie [hidden input]" ;
+    sh:order 5002 ;
+    sh:path lblodBesluit:hasAdditionalTaxRate ;
+    sh:group fields:aDynamicPropertyGroup .
+
+fields:eaf71eec-6ca8-4f63-b4a6-adfe4f21651b a form:Field ;
+    mu:uuid "eaf71eec-6ca8-4f63-b4a6-adfe4f21651b" ;
+    sh:name "TaxType type [hidden input]" ;
+    sh:order 5003 ;
+    sh:path ( lblodBesluit:taxRate rdf:type );
+    sh:group fields:aDynamicPropertyGroup .
+
+##########################################################
+#  END VLABEL [First version]
+##########################################################
+
+##########################################################
+# Centraal bestuur van eredienst:
+#  keeps track of related submissions
+##########################################################
+fields:c0f621fc-4c2c-456b-83f9-f087e64af03a a form:Field ;
+    mu:uuid "c0f621fc-4c2c-456b-83f9-f087e64af03a" ;
+    sh:name "Related submission [hidden input]" ;
+    sh:order 5002 ;
+    sh:path dct:relation;
+    sh:group fields:aDynamicPropertyGroup .
+
+###########Advies-bij-jaarrekening-AGB###########
+
+fieldGroups:b8c40ca1-b2c4-416c-bc3f-e0e4bd50a493 a form:FieldGroup ;
+    mu:uuid "b8c40ca1-b2c4-416c-bc3f-e0e4bd50a493" ; 
+    form:hasField 
+                      ###Ondernemingsnummer-betreffend-bedrijf/bestuur###
+                      fields:6ffb0ed7-769a-41e4-b5a9-f6fb0287b235,
+
+                      ###Naam-betreffend-bedrijf/bestuur###
+                      fields:78bfbd91-0778-4573-a52d-4c53b3c512eb,
+
+                      ###Datum-zitting/besluit###
+                      fields:3dd6ed93-40f7-4d70-a6cb-f4de53dc8bfb,
+
+                      ###Welk-beslissingsorgaan-nam-het-besluit?###
+                      fields:bffbea8d-e55b-4e3d-86e8-ba7aaee7863d,
+
+                      ###Links-naar-documenten###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,
+
+                      ###Bestanden###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95a,
+
+                      ###Type RemoteDataObject or FileDataObject###
+                      fields:355fe001-cdca-48cc-8a6e-88b3aab09874,
+
+                      ### RemoteDataObject/url ###
+                      fields:d0052f0d-90bc-4543-a6b0-e90a1c1117db.
+
+
+fields:0827fafe-ad19-49e1-8b2e-105d2c08a54a form:hasConditionalFieldGroup fields:c13981d3-33a2-4105-9ac0-9823aa52073a.
+
+fields:c13981d3-33a2-4105-9ac0-9823aa52073a a form:ConditionalFieldGroup ;
+    mu:uuid "c13981d3-33a2-4105-9ac0-9823aa52073a";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/a0a709a7-ac07-4457-8d40-de4aea9b1432>
+      ] ;
+    form:hasFieldGroup fieldGroups:b8c40ca1-b2c4-416c-bc3f-e0e4bd50a493 .
+
+
+
+###########Advies-bij-jaarrekening-APB###########
+
+fieldGroups:70fe1278-738f-4edf-b1a1-94056579c7a4 a form:FieldGroup ;
+    mu:uuid "70fe1278-738f-4edf-b1a1-94056579c7a4" ; 
+    form:hasField 
+                      ###Rapportjaar###
+                      fields:41737f90-02d6-4036-8d60-5d5b6ccf939c,
+
+                      ###Naam-betreffend-bedrijf/bestuur###
+                      fields:78bfbd91-0778-4573-a52d-4c53b3c512eb,
+
+                      ###Ondernemingsnummer-betreffend-bedrijf/bestuur###
+                      fields:6ffb0ed7-769a-41e4-b5a9-f6fb0287b235,
+
+                      ###Datum-zitting/besluit###
+                      fields:3dd6ed93-40f7-4d70-a6cb-f4de53dc8bfb,
+
+                      ###Datum-zitting/besluit###
+                      fields:3dd6ed93-40f7-4d70-a6cb-f4de53dc8bfb,
+
+                      ###Welk-beslissingsorgaan-nam-het-besluit?###
+                      fields:bffbea8d-e55b-4e3d-86e8-ba7aaee7863d,
+
+                      ###Rapportjaar###
+                      fields:41737f90-02d6-4036-8d60-5d5b6ccf939c,
+
+                      ###Naam-betreffend-bedrijf/bestuur###
+                      fields:78bfbd91-0778-4573-a52d-4c53b3c512eb,
+
+                      ###Ondernemingsnummer-betreffend-bedrijf/bestuur###
+                      fields:6ffb0ed7-769a-41e4-b5a9-f6fb0287b235,
+
+                      ###Links-naar-documenten###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,
+
+                      ###Bestanden###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95a,
+                      
+                      ###Type RemoteDataObject or FileDataObject###
+                      fields:355fe001-cdca-48cc-8a6e-88b3aab09874,
+
+                      ### RemoteDataObject/url ###
+                      fields:d0052f0d-90bc-4543-a6b0-e90a1c1117db.
+
+fields:0827fafe-ad19-49e1-8b2e-105d2c08a54a form:hasConditionalFieldGroup fields:24e1615a-7ee1-4f55-9aab-baa9140c3024.
+
+fields:24e1615a-7ee1-4f55-9aab-baa9140c3024 a form:ConditionalFieldGroup ;
+    mu:uuid "24e1615a-7ee1-4f55-9aab-baa9140c3024";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/8bdc614a-d2f2-44c0-8cb1-447b1017d312>
+      ] ;
+    form:hasFieldGroup fieldGroups:70fe1278-738f-4edf-b1a1-94056579c7a4 .
+
+
+
+###########Advies-bij-jaarrekening-eredienstbestuur###########
+
+fieldGroups:91045004-2066-40f3-aac1-bf2309eb2b99 a form:FieldGroup ;
+    mu:uuid "91045004-2066-40f3-aac1-bf2309eb2b99" ; 
+    form:hasField 
+                      
+                      ###Eredienst selector###
+                      fields:00a7bce6-2925-4794-93cb-ebd571b28831,
+              
+                      ###Rapportjaar###
+                      fields:41737f90-02d6-4036-8d60-5d5b6ccf939c,
+
+                      ###Datum-zitting/besluit###
+                      fields:3dd6ed93-40f7-4d70-a6cb-f4de53dc8bfb,
+
+                      ###Datum-zitting/besluit###
+                      fields:3dd6ed93-40f7-4d70-a6cb-f4de53dc8bfb,
+
+                      ###Welk-beslissingsorgaan-nam-het-besluit?###
+                      fields:bffbea8d-e55b-4e3d-86e8-ba7aaee7863d,
+
+                      ###Rapportjaar###
+                      fields:41737f90-02d6-4036-8d60-5d5b6ccf939c,
+
+                      ###Links-naar-documenten###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,
+
+                      ###Bestanden###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95a,
+
+                      ###Type RemoteDataObject or FileDataObject###
+                      fields:355fe001-cdca-48cc-8a6e-88b3aab09874,
+
+                      ### RemoteDataObject/url ###
+                      fields:d0052f0d-90bc-4543-a6b0-e90a1c1117db.
+
+fields:0827fafe-ad19-49e1-8b2e-105d2c08a54a form:hasConditionalFieldGroup fields:d6fee4ff-91f7-4a8d-873f-5394eb43c017.
+
+fields:d6fee4ff-91f7-4a8d-873f-5394eb43c017 a form:ConditionalFieldGroup ;
+    mu:uuid "d6fee4ff-91f7-4a8d-873f-5394eb43c017";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/79414af4-4f57-4ca3-aaa4-f8f1e015e71c>
+      ] ;
+    form:hasFieldGroup fieldGroups:91045004-2066-40f3-aac1-bf2309eb2b99 .
+
+
+
+###########Advies-jaarrekening-OCMW-vereniging###########
+
+fieldGroups:e5d8713c-338a-4775-a745-f6f4bad7189e a form:FieldGroup ;
+    mu:uuid "e5d8713c-338a-4775-a745-f6f4bad7189e" ; 
+    form:hasField 
+                      ###Welk-beslissingsorgaan-nam-het-besluit?###
+                      fields:bffbea8d-e55b-4e3d-86e8-ba7aaee7863d,
+
+                      ###Datum-zitting/besluit###
+                      fields:3dd6ed93-40f7-4d70-a6cb-f4de53dc8bfb,
+
+                      ###Naam-betreffend-bedrijf/bestuur###
+                      fields:78bfbd91-0778-4573-a52d-4c53b3c512eb,
+
+                      ###Ondernemingsnummer-betreffend-bedrijf/bestuur###
+                      fields:6ffb0ed7-769a-41e4-b5a9-f6fb0287b235,
+
+                      ###Links-naar-documenten###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,
+
+                      ###Bestanden###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95a,
+
+                      ###Type RemoteDataObject or FileDataObject###
+                      fields:355fe001-cdca-48cc-8a6e-88b3aab09874,
+
+                      ### RemoteDataObject/url ###
+                      fields:d0052f0d-90bc-4543-a6b0-e90a1c1117db.
+
+fields:0827fafe-ad19-49e1-8b2e-105d2c08a54a form:hasConditionalFieldGroup fields:22646d67-09ad-49ab-8f09-e9948c18cbec.
+
+fields:22646d67-09ad-49ab-8f09-e9948c18cbec a form:ConditionalFieldGroup ;
+    mu:uuid "22646d67-09ad-49ab-8f09-e9948c18cbec";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/4350cdda-8291-4055-9026-5c7429357fce>
+      ] ;
+    form:hasFieldGroup fieldGroups:e5d8713c-338a-4775-a745-f6f4bad7189e .
+
+
+
+###########Advies-samenvoeging-eredienstbesturen###########
+
+fieldGroups:53505d5d-d28c-49d2-afaf-910f673d34e1 a form:FieldGroup ;
+    mu:uuid "53505d5d-d28c-49d2-afaf-910f673d34e1" ; 
+    form:hasField 
+                      ###Datum-zitting/besluit###
+                      fields:3dd6ed93-40f7-4d70-a6cb-f4de53dc8bfb,
+
+                      ###Datum-zitting/besluit###
+                      fields:3dd6ed93-40f7-4d70-a6cb-f4de53dc8bfb,
+
+                      ###Welk-beslissingsorgaan-nam-het-besluit?###
+                      fields:bffbea8d-e55b-4e3d-86e8-ba7aaee7863d,
+
+                      ###Links-naar-documenten###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,
+
+                      ###Bestanden###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95a,
+
+                      ###Type RemoteDataObject or FileDataObject###
+                      fields:355fe001-cdca-48cc-8a6e-88b3aab09874,
+
+                      ### RemoteDataObject/url ###
+                      fields:d0052f0d-90bc-4543-a6b0-e90a1c1117db.
+
+fields:0827fafe-ad19-49e1-8b2e-105d2c08a54a form:hasConditionalFieldGroup fields:c2331741-8d43-4fcd-8aae-c2d102e714ff.
+
+fields:c2331741-8d43-4fcd-8aae-c2d102e714ff a form:ConditionalFieldGroup ;
+    mu:uuid "c2331741-8d43-4fcd-8aae-c2d102e714ff";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/4efa4632-efc6-40d5-815a-dec785fbceac>
+      ] ;
+    form:hasFieldGroup fieldGroups:53505d5d-d28c-49d2-afaf-910f673d34e1 .
+
+########### Afwijking principes regiovorming ###########
+
+fieldGroups:109d5a85-fcc7-462a-ac63-ff49f5be5f6a a form:FieldGroup ;
+    mu:uuid "109d5a85-fcc7-462a-ac63-ff49f5be5f6a" ;
+    form:hasField
+
+                      ### Datum-zitting/besluit ###
+                      fields:3dd6ed93-40f7-4d70-a6cb-f4de53dc8bfb,
+
+                      ###Links-naar-documenten ###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,
+
+                      ### Bestanden ###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95a,
+
+                      ### Type RemoteDataObject or FileDataObject ###
+                      fields:355fe001-cdca-48cc-8a6e-88b3aab09874,
+
+                      ### RemoteDataObject/url ###
+                      fields:d0052f0d-90bc-4543-a6b0-e90a1c1117db.
+
+fields:0827fafe-ad19-49e1-8b2e-105d2c08a54a form:hasConditionalFieldGroup fields:109d5a85-fcc7-462a-ac63-ff49f5be5f6d.
+
+fields:109d5a85-fcc7-462a-ac63-ff49f5be5f6d a form:ConditionalFieldGroup ;
+    mu:uuid "109d5a85-fcc7-462a-ac63-ff49f5be5f6d";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitDocumentType/cc831628-95a0-4874-bad5-cdf563896032> # Afwijking principes regiovorming
+      ] ;
+    form:hasFieldGroup fieldGroups:109d5a85-fcc7-462a-ac63-ff49f5be5f6a .
+###########Agenda###########
+
+fieldGroups:0945ac20-fec2-4a08-8cb5-ddec808e0c4c a form:FieldGroup ;
+    mu:uuid "0945ac20-fec2-4a08-8cb5-ddec808e0c4c" ;
+    form:hasField
+                      ###Datum-zitting/agenda###
+                      fields:720c86f8-4537-44b0-850b-fb3452d8bb2d,
+
+                      ###Welk-beslissingsorgaan-nam-het-besluit?###
+                      fields:bffbea8d-e55b-4e3d-86e8-ba7aaee7863d,
+
+                      ###Links-naar-documenten###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,
+
+                      ###Bestanden###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95a,
+
+                      ###Type RemoteDataObject or FileDataObject###
+                      fields:355fe001-cdca-48cc-8a6e-88b3aab09874,
+
+                      ### RemoteDataObject/url ###
+                      fields:d0052f0d-90bc-4543-a6b0-e90a1c1117db.
+
+fields:0827fafe-ad19-49e1-8b2e-105d2c08a54a form:hasConditionalFieldGroup fields:e14b7ae5-f527-4fb8-b1b8-84779bac960b.
+
+fields:e14b7ae5-f527-4fb8-b1b8-84779bac960b a form:ConditionalFieldGroup ;
+    mu:uuid "e14b7ae5-f527-4fb8-b1b8-84779bac960b";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitDocumentType/13fefad6-a9d6-4025-83b5-e4cbee3a8965>
+      ] ;
+    form:hasFieldGroup fieldGroups:0945ac20-fec2-4a08-8cb5-ddec808e0c4c .
+###########VGC Algmeen toezicht###########
+
+fieldGroups:fdfae030-6345-407d-9c77-77fe7ab13ac7 a form:FieldGroup ;
+    mu:uuid "fdfae030-6345-407d-9c77-77fe7ab13ac7" ;
+    form:hasField
+
+                      ###Datum-zitting/besluit###
+                      fields:3dd6ed93-40f7-4d70-a6cb-f4de53dc8bfb,
+
+                      ###Welk-beslissingsorgaan-nam-het-besluit?###
+                      fields:4c7820f0-4011-4ab4-a16a-e128800e11bc,
+
+                      ###Bestanden###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95a,
+
+                      ###Links-naar-documenten###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,
+
+                      ###Type RemoteDataObject or FileDataObject###
+                      fields:355fe001-cdca-48cc-8a6e-88b3aab09874,
+
+                      ### RemoteDataObject/url ###
+                      fields:d0052f0d-90bc-4543-a6b0-e90a1c1117db.
+
+fields:0827fafe-ad19-49e1-8b2e-105d2c08a54a form:hasConditionalFieldGroup fields:4a36c15b-ed7a-4c72-bc45-68658d95eb48.
+
+fields:4a36c15b-ed7a-4c72-bc45-68658d95eb48 a form:ConditionalFieldGroup ;
+    mu:uuid "4a36c15b-ed7a-4c72-bc45-68658d95eb48";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitDocumentType/f4b1b40a-4ac4-4e12-bdd2-84966f274edc>
+      ] ;
+    form:hasFieldGroup fieldGroups:fdfae030-6345-407d-9c77-77fe7ab13ac7 .
+
+
+###########Andere-documenten-BBC###########
+
+fieldGroups:35396e31-45cf-4382-a254-e74bba37ae4c a form:FieldGroup ;
+    mu:uuid "35396e31-45cf-4382-a254-e74bba37ae4c" ; 
+    form:hasField 
+                      ###Opmerking###
+                      fields:0cdfe85f-ec65-498f-bd26-0ec611967de0,
+
+                      ###Dossieromschrijving###
+                      fields:bd6ee5ac-22d6-4279-bcba-3ed279021aac,
+
+                      ###Opmerking###
+                      fields:0cdfe85f-ec65-498f-bd26-0ec611967de0,
+
+                      ###Dossieromschrijving###
+                      fields:bd6ee5ac-22d6-4279-bcba-3ed279021aac,
+
+                      ###Links-naar-documenten###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,
+
+                      ###Bestanden###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95a,
+
+                      ###Type RemoteDataObject or FileDataObject###
+                      fields:355fe001-cdca-48cc-8a6e-88b3aab09874,
+
+                      ### RemoteDataObject/url ###
+                      fields:d0052f0d-90bc-4543-a6b0-e90a1c1117db.
+
+fields:0827fafe-ad19-49e1-8b2e-105d2c08a54a form:hasConditionalFieldGroup fields:17b66f1d-eb1f-4014-af8f-fe436e149662.
+
+fields:17b66f1d-eb1f-4014-af8f-fe436e149662 a form:ConditionalFieldGroup ;
+    mu:uuid "17b66f1d-eb1f-4014-af8f-fe436e149662";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitDocumentType/0ee460b1-5ef4-4d4a-b5e1-e2d7c1d5086e>
+      ] ;
+    form:hasFieldGroup fieldGroups:35396e31-45cf-4382-a254-e74bba37ae4c .
+
+
+
+###########Authentieke akte van de statuten###########
+
+fieldGroups:c059770c-decd-49aa-abbe-82b29a286225 a form:FieldGroup ;
+    mu:uuid "c059770c-decd-49aa-abbe-82b29a286225" ;
+    form:hasField
+                      ###Welk-beslissingsorgaan-nam-het-besluit?###
+                      fields:bffbea8d-e55b-4e3d-86e8-ba7aaee7863d,
+
+                      ###Datum-zitting/besluitenlijst###
+                      fields:ba965704-5a74-4a77-b283-4f97f3b7ddbc,
+
+                      ###Datum-van-publicatie-op-webtoepassing###
+                      fields:49dbe1be-877a-4890-8465-1510ff18ce18,
+
+                      ###Links-naar-documenten###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,
+
+                      ###Bestanden###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95a,
+
+                      ###Type RemoteDataObject or FileDataObject###
+                      fields:355fe001-cdca-48cc-8a6e-88b3aab09874,
+
+                      ### RemoteDataObject/url ###
+                      fields:d0052f0d-90bc-4543-a6b0-e90a1c1117db.
+
+fields:0827fafe-ad19-49e1-8b2e-105d2c08a54a form:hasConditionalFieldGroup fields:c259ff82-08d7-4009-81db-28456c9f6e21 .
+
+fields:c259ff82-08d7-4009-81db-28456c9f6e21 a form:ConditionalFieldGroup ;
+    mu:uuid "c259ff82-08d7-4009-81db-28456c9f6e21";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/bf72e38a-2c73-4484-b82f-c642a4c39d0c>
+      ] ;
+    form:hasFieldGroup fieldGroups:c059770c-decd-49aa-abbe-82b29a286225 .
+
+###########Belasting retributis AGP APB Provincie District###########
+
+fieldGroups:77e949b4-424b-4b34-b8a0-0ee4742edab0 a form:FieldGroup ;
+    mu:uuid "77e949b4-424b-4b34-b8a0-0ee4742edab0" ;
+    form:hasField
+                      ###Datum-zitting/besluit###
+                      fields:3dd6ed93-40f7-4d70-a6cb-f4de53dc8bfb,
+
+                      ###Welk-beslissingsorgaan-nam-het-besluit?###
+                      fields:bffbea8d-e55b-4e3d-86e8-ba7aaee7863d,
+
+                      ###Links-naar-documenten###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,
+
+                      ###Bestanden###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95a,
+
+                      ###Type RemoteDataObject or FileDataObject###
+                      fields:355fe001-cdca-48cc-8a6e-88b3aab09874,
+
+                      ### RemoteDataObject/url ###
+                      fields:d0052f0d-90bc-4543-a6b0-e90a1c1117db.
+
+fields:0827fafe-ad19-49e1-8b2e-105d2c08a54a form:hasConditionalFieldGroup fields:767be21a-c431-4950-abe5-784361ea0fea.
+
+fields:767be21a-c431-4950-abe5-784361ea0fea a form:ConditionalFieldGroup ;
+    mu:uuid "767be21a-c431-4950-abe5-784361ea0fea";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/69e1d8f1-0995-4f34-8372-7b6b447fbb5b>
+      ] ;
+    form:hasFieldGroup fieldGroups:77e949b4-424b-4b34-b8a0-0ee4742edab0 .
+
+
+###########Besluit-budget-AGB###########
+
+fieldGroups:0cb3ea99-0555-4529-a367-0a76de0fc448 a form:FieldGroup ;
+    mu:uuid "0cb3ea99-0555-4529-a367-0a76de0fc448" ; 
+    form:hasField 
+                      ###Ondernemingsnummer-betreffend-bedrijf/bestuur###
+                      fields:6ffb0ed7-769a-41e4-b5a9-f6fb0287b235,
+
+                      ###Naam-betreffend-bedrijf/bestuur###
+                      fields:78bfbd91-0778-4573-a52d-4c53b3c512eb,
+
+                      ###Rapportjaar###
+                      fields:41737f90-02d6-4036-8d60-5d5b6ccf939c,
+
+                      ###Datum-van-publicatie-op-webtoepassing###
+                      fields:49dbe1be-877a-4890-8465-1510ff18ce18,
+
+                      ###Datum-zitting/besluit###
+                      fields:3dd6ed93-40f7-4d70-a6cb-f4de53dc8bfb,
+
+                      ###Datum-zitting/besluit###
+                      fields:3dd6ed93-40f7-4d70-a6cb-f4de53dc8bfb,
+
+                      ###Ondernemingsnummer-betreffend-bedrijf/bestuur###
+                      fields:6ffb0ed7-769a-41e4-b5a9-f6fb0287b235,
+
+                      ###Naam-betreffend-bedrijf/bestuur###
+                      fields:78bfbd91-0778-4573-a52d-4c53b3c512eb,
+
+                      ###Rapportjaar###
+                      fields:41737f90-02d6-4036-8d60-5d5b6ccf939c,
+
+                      ###Welk-beslissingsorgaan-nam-het-besluit?###
+                      fields:4c7820f0-4011-4ab4-a16a-e128800e11bc,
+
+                      ###Links-naar-documenten###
+                      fields:1e0f541f-61e9-43a7-bc5f-612eb44f52bb,
+
+                      ###Bestanden###
+                      fields:c7c5a589-0785-4032-a4bd-ee589add3c39,
+
+                      ###Type RemoteDataObject or FileDataObject###
+                      fields:355fe001-cdca-48cc-8a6e-88b3aab09874,
+
+                      ### RemoteDataObject/url ###
+                      fields:d0052f0d-90bc-4543-a6b0-e90a1c1117db.
+
+fields:0827fafe-ad19-49e1-8b2e-105d2c08a54a form:hasConditionalFieldGroup fields:40384e53-5fa2-49a8-aa52-fabcae68bc62.
+
+fields:40384e53-5fa2-49a8-aa52-fabcae68bc62 a form:ConditionalFieldGroup ;
+    mu:uuid "40384e53-5fa2-49a8-aa52-fabcae68bc62";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/9f12dc58-18ba-4a1f-9e7a-cf73d0b4f025>
+      ] ;
+    form:hasFieldGroup fieldGroups:0cb3ea99-0555-4529-a367-0a76de0fc448 .
+
+
+########### Besluit handhaven na ontvangst schorsingsbesluit - erediensten (bestuur & centraal bestuur) ###########
+
+fieldGroups:90fde57d-8b72-4e4e-b7f2-d04f4e12cf8b a form:FieldGroup ;
+    mu:uuid "90fde57d-8b72-4e4e-b7f2-d04f4e12cf8b" ; 
+    form:hasField
+                      ###Alert (CUSTOM)###
+                      fields:2ab610ad-871b-443e-9b79-3723390ba0c0,
+
+                      ###Datum-zitting/besluit###
+                      fields:3dd6ed93-40f7-4d70-a6cb-f4de53dc8bfb,
+
+                      ###Welk-beslissingsorgaan-nam-het-besluit?###
+                      fields:4c7820f0-4011-4ab4-a16a-e128800e11bc,
+
+                      ###Links-naar-documenten###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,
+
+                      ###Bestanden (CUSTOM)###
+                      fields:1b0b0d89-cb84-45d9-ba07-3a067df84ccc,
+
+                      ###Type RemoteDataObject or FileDataObject###
+                      fields:355fe001-cdca-48cc-8a6e-88b3aab09874,
+
+                      ### RemoteDataObject/url ###
+                      fields:d0052f0d-90bc-4543-a6b0-e90a1c1117db.
+
+fields:0827fafe-ad19-49e1-8b2e-105d2c08a54a form:hasConditionalFieldGroup fields:ed2e8efd-229f-420e-bb7a-0e01575359eb .
+
+fields:ed2e8efd-229f-420e-bb7a-0e01575359eb a form:ConditionalFieldGroup ;
+    mu:uuid "ed2e8efd-229f-420e-bb7a-0e01575359eb";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/41a09f6c-7964-4777-8375-437ef61ed946> 
+      ] ;
+    form:hasFieldGroup fieldGroups:90fde57d-8b72-4e4e-b7f2-d04f4e12cf8b .
+
+
+
+###########Besluit-meerjarenplan(aanpassing)-AGB###########
+
+fieldGroups:c305e982-fbca-4142-b3d9-88f37aa5a9a0 a form:FieldGroup ;
+    mu:uuid "c305e982-fbca-4142-b3d9-88f37aa5a9a0" ; 
+    form:hasField 
+                      ###Gaat-het-over-het-origineel-document-of-over-een-wijziging?###
+                      fields:a8f6a6cb-dbb8-488c-878d-05603791a9eb,
+
+                      ###Ondernemingsnummer-betreffend-bedrijf/bestuur###
+                      fields:6ffb0ed7-769a-41e4-b5a9-f6fb0287b235,
+
+                      ###Naam-betreffend-bedrijf/bestuur###
+                      fields:78bfbd91-0778-4573-a52d-4c53b3c512eb,
+
+                      ###Rapportjaar###
+                      fields:41737f90-02d6-4036-8d60-5d5b6ccf939c,
+
+                      ###Datum-van-publicatie-op-webtoepassing###
+                      fields:49dbe1be-877a-4890-8465-1510ff18ce18,
+
+                      ###Datum-zitting/besluit###
+                      fields:3dd6ed93-40f7-4d70-a6cb-f4de53dc8bfb,
+
+                      ###Datum-zitting/besluit###
+                      fields:3dd6ed93-40f7-4d70-a6cb-f4de53dc8bfb,
+
+                      ###Gaat-het-over-het-origineel-document-of-over-een-wijziging?###
+                      fields:a8f6a6cb-dbb8-488c-878d-05603791a9eb,
+
+                      ###Ondernemingsnummer-betreffend-bedrijf/bestuur###
+                      fields:6ffb0ed7-769a-41e4-b5a9-f6fb0287b235,
+
+                      ###Naam-betreffend-bedrijf/bestuur###
+                      fields:78bfbd91-0778-4573-a52d-4c53b3c512eb,
+
+                      ###Rapportjaar###
+                      fields:41737f90-02d6-4036-8d60-5d5b6ccf939c,
+
+                      ###Welk-beslissingsorgaan-nam-het-besluit?###
+                      fields:4c7820f0-4011-4ab4-a16a-e128800e11bc,
+
+                      ###Links-naar-documenten###
+                      fields:1e0f541f-61e9-43a7-bc5f-612eb44f52bb,
+
+                      ###Bestanden###
+                      fields:c7c5a589-0785-4032-a4bd-ee589add3c39,
+
+                      ###Type RemoteDataObject or FileDataObject###
+                      fields:355fe001-cdca-48cc-8a6e-88b3aab09874,
+
+                      ### RemoteDataObject/url ###
+                      fields:d0052f0d-90bc-4543-a6b0-e90a1c1117db.
+
+fields:0827fafe-ad19-49e1-8b2e-105d2c08a54a form:hasConditionalFieldGroup fields:e6e3271a-a6c9-4a8e-82f2-606856b063c7.
+
+fields:e6e3271a-a6c9-4a8e-82f2-606856b063c7 a form:ConditionalFieldGroup ;
+    mu:uuid "e6e3271a-a6c9-4a8e-82f2-606856b063c7";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/849c66c2-ba33-4ac1-a693-be48d8ac7bc7>
+      ] ;
+    form:hasFieldGroup fieldGroups:c305e982-fbca-4142-b3d9-88f37aa5a9a0 .
+
+
+
+###########Besluit-over-budget(wijziging)-eredienstbestuur###########
+
+fieldGroups:09fd371f-2afe-4b14-81a9-e780876de077 a form:FieldGroup ;
+    mu:uuid "09fd371f-2afe-4b14-81a9-e780876de077" ; 
+    form:hasField 
+
+                      ###Eredienst selector###
+                      fields:00a7bce6-2925-4794-93cb-ebd571b28831,
+
+                      ###Gaat-het-over-het-origineel-document-of-over-een-wijziging?###
+                      fields:a8f6a6cb-dbb8-488c-878d-05603791a9eb,
+
+                      ###Rapportjaar###
+                      fields:41737f90-02d6-4036-8d60-5d5b6ccf939c,
+
+                      ###Datum-zitting/besluit###
+                      fields:3dd6ed93-40f7-4d70-a6cb-f4de53dc8bfb,
+
+                      ###Datum-zitting/besluit###
+                      fields:3dd6ed93-40f7-4d70-a6cb-f4de53dc8bfb,
+
+                      ###Gaat-het-over-het-origineel-document-of-over-een-wijziging?###
+                      fields:a8f6a6cb-dbb8-488c-878d-05603791a9eb,
+
+                      ###Rapportjaar###
+                      fields:41737f90-02d6-4036-8d60-5d5b6ccf939c,
+
+                      ###Welk-beslissingsorgaan-nam-het-besluit?###
+                      fields:4c7820f0-4011-4ab4-a16a-e128800e11bc,
+
+                      ###Links-naar-documenten###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,
+
+                      ###Bestanden###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95a,
+
+                      ###Type RemoteDataObject or FileDataObject###
+                      fields:355fe001-cdca-48cc-8a6e-88b3aab09874,
+
+                      ### RemoteDataObject/url ###
+                      fields:d0052f0d-90bc-4543-a6b0-e90a1c1117db.
+
+fields:0827fafe-ad19-49e1-8b2e-105d2c08a54a form:hasConditionalFieldGroup fields:a262ac48-1511-4744-a332-164f471c150d.
+
+fields:a262ac48-1511-4744-a332-164f471c150d a form:ConditionalFieldGroup ;
+    mu:uuid "a262ac48-1511-4744-a332-164f471c150d";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/df261490-cc74-4f80-b783-41c35e720b46>
+      ] ;
+    form:hasFieldGroup fieldGroups:09fd371f-2afe-4b14-81a9-e780876de077 .
+
+
+
+###########Besluit-over-budget-APB###########
+
+fieldGroups:a0759a1e-ef65-4e39-8cc4-2787ff40d2c9 a form:FieldGroup ;
+    mu:uuid "a0759a1e-ef65-4e39-8cc4-2787ff40d2c9" ; 
+    form:hasField 
+                      ###Ondernemingsnummer-betreffend-bedrijf/bestuur###
+                      fields:6ffb0ed7-769a-41e4-b5a9-f6fb0287b235,
+
+                      ###Naam-betreffend-bedrijf/bestuur###
+                      fields:78bfbd91-0778-4573-a52d-4c53b3c512eb,
+
+                      ###Datum-van-publicatie-op-webtoepassing###
+                      fields:49dbe1be-877a-4890-8465-1510ff18ce18,
+
+                      ###Datum-zitting/besluit###
+                      fields:3dd6ed93-40f7-4d70-a6cb-f4de53dc8bfb,
+
+                      ###Datum-zitting/besluit###
+                      fields:3dd6ed93-40f7-4d70-a6cb-f4de53dc8bfb,
+
+                      ###Ondernemingsnummer-betreffend-bedrijf/bestuur###
+                      fields:6ffb0ed7-769a-41e4-b5a9-f6fb0287b235,
+
+                      ###Naam-betreffend-bedrijf/bestuur###
+                      fields:78bfbd91-0778-4573-a52d-4c53b3c512eb,
+
+                      ###Welk-beslissingsorgaan-nam-het-besluit?###
+                      fields:4c7820f0-4011-4ab4-a16a-e128800e11bc,
+
+                      ###Links-naar-documenten###
+                      fields:1e0f541f-61e9-43a7-bc5f-612eb44f52bb,
+
+                      ###Bestanden###
+                      fields:c7c5a589-0785-4032-a4bd-ee589add3c39,
+
+                      ###Type RemoteDataObject or FileDataObject###
+                      fields:355fe001-cdca-48cc-8a6e-88b3aab09874,
+
+                      ### RemoteDataObject/url ###
+                      fields:d0052f0d-90bc-4543-a6b0-e90a1c1117db.
+
+fields:0827fafe-ad19-49e1-8b2e-105d2c08a54a form:hasConditionalFieldGroup fields:fe5ba124-5298-473f-a74b-3fa1237c3520.
+
+fields:fe5ba124-5298-473f-a74b-3fa1237c3520 a form:ConditionalFieldGroup ;
+    mu:uuid "fe5ba124-5298-473f-a74b-3fa1237c3520";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/82d0696e-1225-4684-826a-923b2453f5e3>
+      ] ;
+    form:hasFieldGroup fieldGroups:a0759a1e-ef65-4e39-8cc4-2787ff40d2c9 .
+
+
+
+###########Besluit-over-meerjarenplan(aanpassing)-eredienstbestuur###########
+
+fieldGroups:ae168679-82cf-4df6-8803-cbcbc6610f47 a form:FieldGroup ;
+    mu:uuid "ae168679-82cf-4df6-8803-cbcbc6610f47" ; 
+    form:hasField 
+
+                      ###Eredienst selector###
+                      fields:00a7bce6-2925-4794-93cb-ebd571b28831,
+
+                      ###Gaat-het-over-het-origineel-document-of-over-een-wijziging?###
+                      fields:a8f6a6cb-dbb8-488c-878d-05603791a9eb,
+
+                      ###Rapportjaar###
+                      fields:41737f90-02d6-4036-8d60-5d5b6ccf939c,
+
+                      ###Datum-zitting/besluit###
+                      fields:3dd6ed93-40f7-4d70-a6cb-f4de53dc8bfb,
+
+                      ###Datum-zitting/besluit###
+                      fields:3dd6ed93-40f7-4d70-a6cb-f4de53dc8bfb,
+
+                      ###Gaat-het-over-het-origineel-document-of-over-een-wijziging?###
+                      fields:a8f6a6cb-dbb8-488c-878d-05603791a9eb,
+
+                      ###Rapportjaar###
+                      fields:41737f90-02d6-4036-8d60-5d5b6ccf939c,
+
+                      ###Welk-beslissingsorgaan-nam-het-besluit?###
+                      fields:4c7820f0-4011-4ab4-a16a-e128800e11bc,
+
+                      ###Links-naar-documenten###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,
+
+                      ###Bestanden###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95a,
+
+                      ###Type RemoteDataObject or FileDataObject###
+                      fields:355fe001-cdca-48cc-8a6e-88b3aab09874,
+
+                      ### RemoteDataObject/url ###
+                      fields:d0052f0d-90bc-4543-a6b0-e90a1c1117db.
+
+fields:0827fafe-ad19-49e1-8b2e-105d2c08a54a form:hasConditionalFieldGroup fields:c5541662-1c03-446f-837c-8c56d3db5a27.
+
+fields:c5541662-1c03-446f-837c-8c56d3db5a27 a form:ConditionalFieldGroup ;
+    mu:uuid "c5541662-1c03-446f-837c-8c56d3db5a27";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/3fcf7dba-2e5b-4955-a489-6dd8285c013b>
+      ] ;
+    form:hasFieldGroup fieldGroups:ae168679-82cf-4df6-8803-cbcbc6610f47 .
+
+
+
+###########Besluit-over-meerjarenplan-APB###########
+
+fieldGroups:deb4e777-eb33-4884-a2cd-859e20c9cf71 a form:FieldGroup ;
+    mu:uuid "deb4e777-eb33-4884-a2cd-859e20c9cf71" ; 
+    form:hasField 
+                      ###Ondernemingsnummer-betreffend-bedrijf/bestuur###
+                      fields:6ffb0ed7-769a-41e4-b5a9-f6fb0287b235,
+
+                      ###Naam-betreffend-bedrijf/bestuur###
+                      fields:78bfbd91-0778-4573-a52d-4c53b3c512eb,
+
+                      ###Datum-zitting/besluit###
+                      fields:3dd6ed93-40f7-4d70-a6cb-f4de53dc8bfb,
+
+                      ###Datum-zitting/besluit###
+                      fields:3dd6ed93-40f7-4d70-a6cb-f4de53dc8bfb,
+
+                      ###Datum-van-publicatie-op-webtoepassing###
+                      fields:49dbe1be-877a-4890-8465-1510ff18ce18,
+
+                      ###Ondernemingsnummer-betreffend-bedrijf/bestuur###
+                      fields:6ffb0ed7-769a-41e4-b5a9-f6fb0287b235,
+
+                      ###Naam-betreffend-bedrijf/bestuur###
+                      fields:78bfbd91-0778-4573-a52d-4c53b3c512eb,
+
+                      ###Welk-beslissingsorgaan-nam-het-besluit?###
+                      fields:4c7820f0-4011-4ab4-a16a-e128800e11bc,
+
+                      ###Links-naar-documenten###
+                      fields:1e0f541f-61e9-43a7-bc5f-612eb44f52bb,
+
+                      ###Bestanden###
+                      fields:c7c5a589-0785-4032-a4bd-ee589add3c39,
+
+                      ###Type RemoteDataObject or FileDataObject###
+                      fields:355fe001-cdca-48cc-8a6e-88b3aab09874,
+
+                      ### RemoteDataObject/url ###
+                      fields:d0052f0d-90bc-4543-a6b0-e90a1c1117db.
+
+fields:0827fafe-ad19-49e1-8b2e-105d2c08a54a form:hasConditionalFieldGroup fields:7b7368be-3f98-4a56-993f-39443d92cc1d.
+
+fields:7b7368be-3f98-4a56-993f-39443d92cc1d a form:ConditionalFieldGroup ;
+    mu:uuid "7b7368be-3f98-4a56-993f-39443d92cc1d";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/c417f3da-a3bd-47c5-84bf-29007323a362>
+      ] ;
+    form:hasFieldGroup fieldGroups:deb4e777-eb33-4884-a2cd-859e20c9cf71 .
+
+###########Besluit financieel document eredienstbestuur###########
+
+fieldGroups:36679664-25b5-4e2d-8a58-585e00d595e1 a form:FieldGroup ;
+    mu:uuid "36679664-25b5-4e2d-8a58-585e00d595e1" ;
+    form:hasField
+                      ###Datum-zitting/besluit###
+                      fields:3dd6ed93-40f7-4d70-a6cb-f4de53dc8bfb,
+
+                      ###Welk-beslissingsorgaan-nam-het-besluit?###
+                      fields:bffbea8d-e55b-4e3d-86e8-ba7aaee7863d,
+
+                      ###Links-naar-documenten###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,
+
+                      ###Bestanden###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95a,
+
+                      ###Type RemoteDataObject or FileDataObject###
+                      fields:355fe001-cdca-48cc-8a6e-88b3aab09874,
+
+                      ### RemoteDataObject/url ###
+                      fields:d0052f0d-90bc-4543-a6b0-e90a1c1117db.
+
+fields:0827fafe-ad19-49e1-8b2e-105d2c08a54a form:hasConditionalFieldGroup fields:e2921d43-804b-43b7-b4d2-c0cf8faffb32.
+
+fields:e2921d43-804b-43b7-b4d2-c0cf8faffb32 a form:ConditionalFieldGroup ;
+    mu:uuid "e2921d43-804b-43b7-b4d2-c0cf8faffb32";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/98dcd0be-b0c4-4051-a931-f837140bbe93>
+      ] ;
+    form:hasFieldGroup fieldGroups:36679664-25b5-4e2d-8a58-585e00d595e1 .
+########### budget wijziging ocmw ###########
+
+fieldGroups:9991d11c-e83b-45db-baad-68ad1147cef0 a form:FieldGroup ;
+    mu:uuid "9991d11c-e83b-45db-baad-68ad1147cef0" ;
+    form:hasField
+                      ###Datum-zitting/besluit###
+                      fields:3dd6ed93-40f7-4d70-a6cb-f4de53dc8bfb,
+
+                      ###Welk-beslissingsorgaan-nam-het-besluit?###
+                      fields:bffbea8d-e55b-4e3d-86e8-ba7aaee7863d,
+
+                      ###Links-naar-documenten###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,
+
+                      ###Bestanden###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95a,
+
+                      ###Type RemoteDataObject or FileDataObject###
+                      fields:355fe001-cdca-48cc-8a6e-88b3aab09874,
+
+                      ### RemoteDataObject/url ###
+                      fields:d0052f0d-90bc-4543-a6b0-e90a1c1117db.
+
+fields:0827fafe-ad19-49e1-8b2e-105d2c08a54a form:hasConditionalFieldGroup fields:e40c78e9-5942-42e5-ae32-2357fadad288.
+
+fields:e40c78e9-5942-42e5-ae32-2357fadad288 a form:ConditionalFieldGroup ;
+    mu:uuid "e40c78e9-5942-42e5-ae32-2357fadad288";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/3f9919e0-868e-4f83-a3d3-300df65022ab>
+      ] ;
+    form:hasFieldGroup fieldGroups:9991d11c-e83b-45db-baad-68ad1147cef0 .
+########### budget wijziging ocmw-vereniging ###########
+
+fieldGroups:fbdc9d22-bd48-42b9-95ca-e96d0af7f2bf a form:FieldGroup ;
+    mu:uuid "fbdc9d22-bd48-42b9-95ca-e96d0af7f2bf" ;
+    form:hasField
+                      ###Datum-zitting/besluit###
+                      fields:3dd6ed93-40f7-4d70-a6cb-f4de53dc8bfb,
+
+                      ###Welk-beslissingsorgaan-nam-het-besluit?###
+                      fields:4c7820f0-4011-4ab4-a16a-e128800e11bc,
+
+                      ###Links-naar-documenten###
+                      fields:1e0f541f-61e9-43a7-bc5f-612eb44f52bb,
+
+                      ###Bestanden###
+                      fields:c7c5a589-0785-4032-a4bd-ee589add3c39,
+
+                      ###Type RemoteDataObject or FileDataObject###
+                      fields:355fe001-cdca-48cc-8a6e-88b3aab09874,
+
+                      ### RemoteDataObject/url ###
+                      fields:d0052f0d-90bc-4543-a6b0-e90a1c1117db.
+
+fields:0827fafe-ad19-49e1-8b2e-105d2c08a54a form:hasConditionalFieldGroup fields:2c0c9e5a-4205-45a9-9f63-6d19af345e81.
+
+fields:2c0c9e5a-4205-45a9-9f63-6d19af345e81 a form:ConditionalFieldGroup ;
+    mu:uuid "2c0c9e5a-4205-45a9-9f63-6d19af345e81";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/70ae4d36-de0c-425d-9dbe-3b6deef8343c>
+      ] ;
+    form:hasFieldGroup fieldGroups:fbdc9d22-bd48-42b9-95ca-e96d0af7f2bf .
+###########Jaarrekening AGB###########
+
+fieldGroups:7bea30d4-39e9-4daf-9cca-fc07548cb7e1 a form:FieldGroup ;
+    mu:uuid "7bea30d4-39e9-4daf-9cca-fc07548cb7e1" ;
+    form:hasField
+                      ###Datum-zitting/besluit###
+                      fields:3dd6ed93-40f7-4d70-a6cb-f4de53dc8bfb,
+
+                      ###Welk-beslissingsorgaan-nam-het-besluit?###
+                      fields:bffbea8d-e55b-4e3d-86e8-ba7aaee7863d,
+
+                      ###Links-naar-documenten###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,
+
+                      ###Bestanden###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95a,
+
+                      ###Type RemoteDataObject or FileDataObject###
+                      fields:355fe001-cdca-48cc-8a6e-88b3aab09874,
+
+                      ### RemoteDataObject/url ###
+                      fields:d0052f0d-90bc-4543-a6b0-e90a1c1117db.
+
+fields:0827fafe-ad19-49e1-8b2e-105d2c08a54a form:hasConditionalFieldGroup fields:42a457eb-8175-4448-82c7-ff243ea8c860.
+
+fields:42a457eb-8175-4448-82c7-ff243ea8c860 a form:ConditionalFieldGroup ;
+    mu:uuid "42a457eb-8175-4448-82c7-ff243ea8c860";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/14c76c63-b0f8-48c2-9891-c649f9151ea2>
+      ] ;
+    form:hasFieldGroup fieldGroups:7bea30d4-39e9-4daf-9cca-fc07548cb7e1 .
+###########jaarrekening ocmw###########
+
+fieldGroups:400c641f-3ffb-493a-ac2c-9e4dabce9095 a form:FieldGroup ;
+    mu:uuid "400c641f-3ffb-493a-ac2c-9e4dabce9095" ;
+    form:hasField
+                      ###Datum-zitting/besluit###
+                      fields:3dd6ed93-40f7-4d70-a6cb-f4de53dc8bfb,
+
+                      ###Welk-beslissingsorgaan-nam-het-besluit?###
+                      fields:bffbea8d-e55b-4e3d-86e8-ba7aaee7863d,
+
+                      ###Links-naar-documenten###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,
+
+                      ###Bestanden###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95a,
+
+                      ###Type RemoteDataObject or FileDataObject###
+                      fields:355fe001-cdca-48cc-8a6e-88b3aab09874,
+
+                      ### RemoteDataObject/url ###
+                      fields:d0052f0d-90bc-4543-a6b0-e90a1c1117db.
+
+fields:0827fafe-ad19-49e1-8b2e-105d2c08a54a form:hasConditionalFieldGroup fields:8b14f936-8833-4228-a595-b98291c3e547.
+
+fields:8b14f936-8833-4228-a595-b98291c3e547 a form:ConditionalFieldGroup ;
+    mu:uuid "8b14f936-8833-4228-a595-b98291c3e547";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/1fdd091b-a5ac-4f00-b19f-9186f05a32f6>
+      ] ;
+    form:hasFieldGroup fieldGroups:400c641f-3ffb-493a-ac2c-9e4dabce9095 .
+###########Jaarrekening OCMWv###########
+
+fieldGroups:f451f1ae-ea1f-4457-8116-2220df77b44d a form:FieldGroup ;
+    mu:uuid "f451f1ae-ea1f-4457-8116-2220df77b44d" ;
+    form:hasField
+                      ###Datum-zitting/besluit###
+                      fields:3dd6ed93-40f7-4d70-a6cb-f4de53dc8bfb,
+
+                      ###Welk-beslissingsorgaan-nam-het-besluit?###
+                      fields:bffbea8d-e55b-4e3d-86e8-ba7aaee7863d,
+
+                      ###Links-naar-documenten###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,
+
+                      ###Bestanden###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95a,
+
+                      ###Type RemoteDataObject or FileDataObject###
+                      fields:355fe001-cdca-48cc-8a6e-88b3aab09874,
+
+                      ### RemoteDataObject/url ###
+                      fields:d0052f0d-90bc-4543-a6b0-e90a1c1117db.
+
+fields:0827fafe-ad19-49e1-8b2e-105d2c08a54a form:hasConditionalFieldGroup fields:75b8fb8c-f1b5-4a50-adc4-b0d4634b5a67.
+
+fields:75b8fb8c-f1b5-4a50-adc4-b0d4634b5a67 a form:ConditionalFieldGroup ;
+    mu:uuid "75b8fb8c-f1b5-4a50-adc4-b0d4634b5a67";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/8b5ff213-1866-4d4c-8d67-af0cdc1acf33>
+      ] ;
+    form:hasFieldGroup fieldGroups:f451f1ae-ea1f-4457-8116-2220df77b44d .
+###########meerjarenplan ocmw ###########
+
+fieldGroups:752ea48c-4729-435c-a765-c0707db004cc a form:FieldGroup ;
+    mu:uuid "752ea48c-4729-435c-a765-c0707db004cc" ;
+    form:hasField
+                      ###Datum-zitting/besluit###
+                      fields:3dd6ed93-40f7-4d70-a6cb-f4de53dc8bfb,
+
+                      ###Welk-beslissingsorgaan-nam-het-besluit?###
+                      fields:bffbea8d-e55b-4e3d-86e8-ba7aaee7863d,
+
+                      ###Links-naar-documenten###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,
+
+                      ###Bestanden###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95a,
+
+                      ###Type RemoteDataObject or FileDataObject###
+                      fields:355fe001-cdca-48cc-8a6e-88b3aab09874,
+
+                      ### RemoteDataObject/url ###
+                      fields:d0052f0d-90bc-4543-a6b0-e90a1c1117db.
+
+fields:0827fafe-ad19-49e1-8b2e-105d2c08a54a form:hasConditionalFieldGroup fields:90d80b85-5491-4e85-bff3-f7fbf73c7c87.
+
+fields:90d80b85-5491-4e85-bff3-f7fbf73c7c87 a form:ConditionalFieldGroup ;
+    mu:uuid "90d80b85-5491-4e85-bff3-f7fbf73c7c87";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/6ca1d146-f439-4ad9-9e36-be026f43762f>
+      ] ;
+    form:hasFieldGroup fieldGroups:752ea48c-4729-435c-a765-c0707db004cc .
+fieldGroups:8a812873-604f-423c-b42e-d0b28aac5f53 a form:FieldGroup ;
+    mu:uuid "8a812873-604f-423c-b42e-d0b28aac5f53" ;
+    form:hasField
+
+                      ###Links-naar-documenten###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,
+
+                      ###Bestanden###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95a.
+
+# this field is the custom bestuursorgaan selector
+fields:4c7820f0-4011-4ab4-a16a-e128800e11bc form:hasConditionalFieldGroup fields:bbdc52b0-474f-463f-944e-7ccc336c99bc.
+
+fields:bbdc52b0-474f-463f-944e-7ccc336c99bc a form:ConditionalFieldGroup ;
+    mu:uuid "bbdc52b0-474f-463f-944e-7ccc336c99bc";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitDocumentType/3fa67785-ffdc-4b30-8880-2b99d97b4dee>
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuursorgaanClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> # Algemene vergadering
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:bestuurt besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuurseenheidClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/36a82ba0-7ff1-4697-a9dd-2e94df73b721> # Autonoom gemeentebedrijf
+      ] ;
+    form:hasFieldGroup fieldGroups:8a812873-604f-423c-b42e-d0b28aac5f53 .fieldGroups:22c1c769-e6e7-4daa-98e8-2f17614caead a form:FieldGroup ;
+    mu:uuid "22c1c769-e6e7-4daa-98e8-2f17614caead" ;
+    form:hasField
+
+                      ###Links-naar-documenten###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,
+
+                      ###Bestanden###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95a.
+
+# this field is the custom bestuursorgaan selector
+fields:4c7820f0-4011-4ab4-a16a-e128800e11bc form:hasConditionalFieldGroup fields:0896ea73-1f49-4dcb-b244-165637747d56.
+
+fields:0896ea73-1f49-4dcb-b244-165637747d56 a form:ConditionalFieldGroup ;
+    mu:uuid "0896ea73-1f49-4dcb-b244-165637747d56";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitDocumentType/3fa67785-ffdc-4b30-8880-2b99d97b4dee>
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuursorgaanClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> # Algemene vergadering
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:bestuurt besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuurseenheidClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/80310756-ce0a-4a1b-9b8e-7c01b6cc7a2d> # Autonoom provinciebedrijf
+      ] ;
+    form:hasFieldGroup fieldGroups:22c1c769-e6e7-4daa-98e8-2f17614caead .fieldGroups:8bfa3899-55fc-40a7-94a4-0f970f7e4469 a form:FieldGroup ;
+    mu:uuid "8bfa3899-55fc-40a7-94a4-0f970f7e4469" ;
+    form:hasField
+
+                      ###Links-naar-documenten###
+                      fields:1e0f541f-61e9-43a7-bc5f-612eb44f52bb,
+
+                      ###Bestanden###
+                      fields:c7c5a589-0785-4032-a4bd-ee589add3c39.
+
+# this field is the custom bestuursorgaan selector
+fields:4c7820f0-4011-4ab4-a16a-e128800e11bc form:hasConditionalFieldGroup fields:0627d094-22be-4d35-b964-7844ff8428b4.
+
+fields:0627d094-22be-4d35-b964-7844ff8428b4 a form:ConditionalFieldGroup ;
+    mu:uuid "0627d094-22be-4d35-b964-7844ff8428b4";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitDocumentType/3fa67785-ffdc-4b30-8880-2b99d97b4dee>
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuursorgaanClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> # Algemene vergadering
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:bestuurt besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuurseenheidClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/d01bb1f6-2439-4e33-9c25-1fc295de2e71> # Dienstverlenende vereniging
+      ] ;
+    form:hasFieldGroup fieldGroups:8bfa3899-55fc-40a7-94a4-0f970f7e4469 .fieldGroups:7fe7bcb9-f262-4285-8f55-2690e68af484 a form:FieldGroup ;
+    mu:uuid "7fe7bcb9-f262-4285-8f55-2690e68af484" ;
+    form:hasField
+
+                      ###Links-naar-documenten###
+                      fields:1e0f541f-61e9-43a7-bc5f-612eb44f52bb,
+
+                      ###Bestanden###
+                      fields:c7c5a589-0785-4032-a4bd-ee589add3c39.
+
+# this field is the custom bestuursorgaan selector
+fields:4c7820f0-4011-4ab4-a16a-e128800e11bc form:hasConditionalFieldGroup fields:f0b22a54-8e1c-420c-9d38-162f2107c9a4.
+
+fields:f0b22a54-8e1c-420c-9d38-162f2107c9a4 a form:ConditionalFieldGroup ;
+    mu:uuid "f0b22a54-8e1c-420c-9d38-162f2107c9a4";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitDocumentType/3fa67785-ffdc-4b30-8880-2b99d97b4dee>
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuursorgaanClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> # Algemene vergadering
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:bestuurt besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuurseenheidClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/cc4e2d67-603b-4784-9b61-e50bac1ec089> # OCMW vereniging
+      ] ;
+    form:hasFieldGroup fieldGroups:7fe7bcb9-f262-4285-8f55-2690e68af484 .fieldGroups:8794bebf-76be-40a1-a810-3176787e86b4 a form:FieldGroup ;
+    mu:uuid "8794bebf-76be-40a1-a810-3176787e86b4" ;
+    form:hasField
+
+                      ###Links-naar-documenten###
+                      fields:1e0f541f-61e9-43a7-bc5f-612eb44f52bb,
+
+                      ###Bestanden###
+                      fields:c7c5a589-0785-4032-a4bd-ee589add3c39.
+
+# this field is the custom bestuursorgaan selector
+fields:4c7820f0-4011-4ab4-a16a-e128800e11bc form:hasConditionalFieldGroup fields:2da18d55-4195-432a-b982-b41702d56e56.
+
+fields:2da18d55-4195-432a-b982-b41702d56e56 a form:ConditionalFieldGroup ;
+    mu:uuid "2da18d55-4195-432a-b982-b41702d56e56";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitDocumentType/3fa67785-ffdc-4b30-8880-2b99d97b4dee>
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuursorgaanClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> # Algemene vergadering
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:bestuurt besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuurseenheidClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/cd93f147-3ece-4308-acab-5c5ada3ec63d> # Opdrachthoudende vereniging
+      ] ;
+    form:hasFieldGroup fieldGroups:8794bebf-76be-40a1-a810-3176787e86b4 .fieldGroups:4a41de32-e793-416b-9270-55c0617b1abf a form:FieldGroup ;
+    mu:uuid "4a41de32-e793-416b-9270-55c0617b1abf" ;
+    form:hasField
+
+                      ###Links-naar-documenten###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,
+
+                      ###Bestanden###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95a.
+
+# this field is the custom bestuursorgaan selector
+fields:4c7820f0-4011-4ab4-a16a-e128800e11bc form:hasConditionalFieldGroup fields:e5a0028c-20e6-46fd-a6c0-2aa732e3124c.
+
+fields:e5a0028c-20e6-46fd-a6c0-2aa732e3124c a form:ConditionalFieldGroup ;
+    mu:uuid "e5a0028c-20e6-46fd-a6c0-2aa732e3124c";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitDocumentType/3fa67785-ffdc-4b30-8880-2b99d97b4dee>
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuursorgaanClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/0dbc70ec-6be9-4997-b8e1-11b6c0542382> # Bevoegd beslissingsorgaan
+      ] ;
+    form:hasFieldGroup fieldGroups:4a41de32-e793-416b-9270-55c0617b1abf .fieldGroups:4c21f87c-e1bd-448e-b5d3-b40c8614e4f2 a form:FieldGroup ;
+    mu:uuid "4c21f87c-e1bd-448e-b5d3-b40c8614e4f2" ;
+    form:hasField
+
+                      ###Links-naar-documenten###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,
+
+                      ###Bestanden###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95a.
+
+# this field is the custom bestuursorgaan selector
+fields:4c7820f0-4011-4ab4-a16a-e128800e11bc form:hasConditionalFieldGroup fields:4e717505-5784-4711-b494-5125b2c94b59.
+
+fields:4e717505-5784-4711-b494-5125b2c94b59 a form:ConditionalFieldGroup ;
+    mu:uuid "4e717505-5784-4711-b494-5125b2c94b59";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitDocumentType/3fa67785-ffdc-4b30-8880-2b99d97b4dee>
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuursorgaanClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000009> # Bijzonder Comité voor de Sociale Dienst
+      ] ;
+    form:hasFieldGroup fieldGroups:4c21f87c-e1bd-448e-b5d3-b40c8614e4f2 .fieldGroups:f46f59e8-c145-4498-95e4-f59151b9cc35 a form:FieldGroup ;
+    mu:uuid "f46f59e8-c145-4498-95e4-f59151b9cc35" ;
+    form:hasField
+
+                      ###Links-naar-documenten###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,
+
+                      ###Bestanden###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95a.
+
+# this field is the custom bestuursorgaan selector
+fields:4c7820f0-4011-4ab4-a16a-e128800e11bc form:hasConditionalFieldGroup fields:3a079210d-0f29-4ec8-b10a-502ab8be7735.
+
+fields:3a079210d-0f29-4ec8-b10a-502ab8be7735 a form:ConditionalFieldGroup ;
+    mu:uuid "3a079210d-0f29-4ec8-b10a-502ab8be7735";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitDocumentType/3fa67785-ffdc-4b30-8880-2b99d97b4dee>
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuursorgaanClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/4955bd72cd0e4eb895fdbfab08da0284> # burgemeester
+      ] ;
+    form:hasFieldGroup fieldGroups:f46f59e8-c145-4498-95e4-f59151b9cc35 .fieldGroups:a77e3890-edea-42e8-b78b-b92dc48aeac1 a form:FieldGroup ;
+    mu:uuid "a77e3890-edea-42e8-b78b-b92dc48aeac1" ;
+    form:hasField
+
+                      ###Links-naar-documenten###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,
+
+                      ###Bestanden###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95a.
+
+# this field is the custom bestuursorgaan selector
+fields:4c7820f0-4011-4ab4-a16a-e128800e11bc form:hasConditionalFieldGroup fields:320f02cff-654c-4c6d-8641-82b0008d9fdc.
+
+fields:320f02cff-654c-4c6d-8641-82b0008d9fdc a form:ConditionalFieldGroup ;
+    mu:uuid "320f02cff-654c-4c6d-8641-82b0008d9fdc";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitDocumentType/3fa67785-ffdc-4b30-8880-2b99d97b4dee>
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuursorgaanClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000006> # college van schepenen en burgermeester
+      ] ;
+    form:hasFieldGroup fieldGroups:a77e3890-edea-42e8-b78b-b92dc48aeac1 .fieldGroups:2f758e4f-45b0-4f53-a2d4-7153f73f553b a form:FieldGroup ;
+    mu:uuid "2f758e4f-45b0-4f53-a2d4-7153f73f553b" ;
+    form:hasField
+
+                      ###Links-naar-documenten###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,
+
+                      ###Bestanden###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95a.
+
+# this field is the custom bestuursorgaan selector
+fields:4c7820f0-4011-4ab4-a16a-e128800e11bc form:hasConditionalFieldGroup fields:c8acd61d-a126-4ceb-b06f-afa714673931.
+
+fields:c8acd61d-a126-4ceb-b06f-afa714673931 a form:ConditionalFieldGroup ;
+    mu:uuid "c8acd61d-a126-4ceb-b06f-afa714673931";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitDocumentType/3fa67785-ffdc-4b30-8880-2b99d97b4dee>
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuursorgaanClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e00000d> # deputatie
+      ] ;
+    form:hasFieldGroup fieldGroups:2f758e4f-45b0-4f53-a2d4-7153f73f553b .fieldGroups:77a831ca-cf28-45a3-a04b-9c91e9c373df a form:FieldGroup ;
+    mu:uuid "77a831ca-cf28-45a3-a04b-9c91e9c373df" ;
+    form:hasField
+
+                      ###Links-naar-documenten###
+                      fields:1e0f541f-61e9-43a7-bc5f-612eb44f52bb,
+
+                      ###Bestanden###
+                      fields:c7c5a589-0785-4032-a4bd-ee589add3c39.
+
+# this field is the custom bestuursorgaan selector
+fields:4c7820f0-4011-4ab4-a16a-e128800e11bc form:hasConditionalFieldGroup fields:e583e92c-d13c-4c0a-bf40-bb0be75f63eb.
+
+fields:e583e92c-d13c-4c0a-bf40-bb0be75f63eb a form:ConditionalFieldGroup ;
+    mu:uuid "e583e92c-d13c-4c0a-bf40-bb0be75f63eb";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitDocumentType/3fa67785-ffdc-4b30-8880-2b99d97b4dee>
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuursorgaanClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5733254e-73ff-4844-8d43-7afb7ec726e8> # directiecomité
+      ] ;
+    form:hasFieldGroup fieldGroups:77a831ca-cf28-45a3-a04b-9c91e9c373df .fieldGroups:1084826b-b56d-4f28-aed8-3d85c2981655 a form:FieldGroup ;
+    mu:uuid "1084826b-b56d-4f28-aed8-3d85c2981655" ;
+    form:hasField
+
+                      ###Links-naar-documenten###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,
+
+                      ###Bestanden###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95a.
+
+# this field is the custom bestuursorgaan selector
+fields:4c7820f0-4011-4ab4-a16a-e128800e11bc form:hasConditionalFieldGroup fields:4167f824-2f68-424a-a91e-c820c9bb1d80.
+
+fields:4167f824-2f68-424a-a91e-c820c9bb1d80 a form:ConditionalFieldGroup ;
+    mu:uuid "4167f824-2f68-424a-a91e-c820c9bb1d80";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitDocumentType/3fa67785-ffdc-4b30-8880-2b99d97b4dee>
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuursorgaanClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/9314533e-891f-4d84-a492-0338af104065> # Districtsburgemeester
+      ] ;
+    form:hasFieldGroup fieldGroups:1084826b-b56d-4f28-aed8-3d85c2981655 .fieldGroups:3dba68fb-b3f1-4cec-a4c7-8099e1f6be58 a form:FieldGroup ;
+    mu:uuid "3dba68fb-b3f1-4cec-a4c7-8099e1f6be58" ;
+    form:hasField
+
+                      ###Links-naar-documenten###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,
+
+                      ###Bestanden###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95a.
+
+# this field is the custom bestuursorgaan selector
+fields:4c7820f0-4011-4ab4-a16a-e128800e11bc form:hasConditionalFieldGroup fields:63f71c95-39be-4516-a6b6-d88a880643c6.
+
+fields:63f71c95-39be-4516-a6b6-d88a880643c6 a form:ConditionalFieldGroup ;
+    mu:uuid "63f71c95-39be-4516-a6b6-d88a880643c6";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitDocumentType/3fa67785-ffdc-4b30-8880-2b99d97b4dee>
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuursorgaanClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e00000b> # Districtscollege
+      ] ;
+    form:hasFieldGroup fieldGroups:3dba68fb-b3f1-4cec-a4c7-8099e1f6be58 .fieldGroups:3179bccc-8fc7-474d-87f6-5832fd81f4b9 a form:FieldGroup ;
+    mu:uuid "3179bccc-8fc7-474d-87f6-5832fd81f4b9" ;
+    form:hasField
+
+                      ###Links-naar-documenten###
+                      fields:1e0f541f-61e9-43a7-bc5f-612eb44f52bb,
+
+                      ###Bestanden###
+                      fields:c7c5a589-0785-4032-a4bd-ee589add3c39.
+
+# this field is the custom bestuursorgaan selector
+fields:4c7820f0-4011-4ab4-a16a-e128800e11bc form:hasConditionalFieldGroup fields:4ae5083e-84c3-43b5-9d9c-a158f99c4427.
+
+fields:4ae5083e-84c3-43b5-9d9c-a158f99c4427 a form:ConditionalFieldGroup ;
+    mu:uuid "4ae5083e-84c3-43b5-9d9c-a158f99c4427";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitDocumentType/3fa67785-ffdc-4b30-8880-2b99d97b4dee>
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuursorgaanClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e00000a> # Districtsraad
+      ] ;
+    form:hasFieldGroup fieldGroups:3179bccc-8fc7-474d-87f6-5832fd81f4b9 .###########Besluitenlijst###########
+
+fieldGroups:64b712f3-c061-4368-919e-6ea6afb45192 a form:FieldGroup ;
+    mu:uuid "64b712f3-c061-4368-919e-6ea6afb45192" ; 
+    form:hasField 
+                      ###Welk-beslissingsorgaan-nam-het-besluit?###
+                      fields:4c7820f0-4011-4ab4-a16a-e128800e11bc,
+
+                      ###Datum-zitting/besluitenlijst###
+                      fields:ba965704-5a74-4a77-b283-4f97f3b7ddbc,
+
+                      ###Datum-van-publicatie-op-webtoepassing###
+                      fields:49dbe1be-877a-4890-8465-1510ff18ce18,
+
+                      ###Type RemoteDataObject or FileDataObject###
+                      fields:355fe001-cdca-48cc-8a6e-88b3aab09874,
+
+                      ### RemoteDataObject/url ###
+                      fields:d0052f0d-90bc-4543-a6b0-e90a1c1117db,
+
+                      ### Bestuursorgaan classificatie code [hidden input] ###
+                      fields:303545a6-705b-43b3-86b7-b96436524be9,
+
+                      ### Bestuurseenheid classificatie code [hidden input] ###
+                      fields:ac32a491-4b5c-4a7e-973f-fad6127c9433.
+
+fields:0827fafe-ad19-49e1-8b2e-105d2c08a54a form:hasConditionalFieldGroup fields:d75438e8-a4c5-4b39-a606-e198fdeb7aec.
+
+fields:d75438e8-a4c5-4b39-a606-e198fdeb7aec a form:ConditionalFieldGroup ;
+    mu:uuid "d75438e8-a4c5-4b39-a606-e198fdeb7aec";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitDocumentType/3fa67785-ffdc-4b30-8880-2b99d97b4dee>
+      ] ;
+    form:hasFieldGroup fieldGroups:64b712f3-c061-4368-919e-6ea6afb45192 .
+
+fieldGroups:7e26db7b-e864-4afe-ad2b-1753434f3e3f a form:FieldGroup ;
+    mu:uuid "7e26db7b-e864-4afe-ad2b-1753434f3e3f" ;
+    form:hasField
+
+                      ###Links-naar-documenten###
+                      fields:1e0f541f-61e9-43a7-bc5f-612eb44f52bb,
+
+                      ###Bestanden###
+                      fields:c7c5a589-0785-4032-a4bd-ee589add3c39.
+
+# this field is the custom bestuursorgaan selector
+fields:4c7820f0-4011-4ab4-a16a-e128800e11bc form:hasConditionalFieldGroup fields:335b1a8a-e6d6-11ea-bf88-8b5df92c347a.
+
+fields:335b1a8a-e6d6-11ea-bf88-8b5df92c347a a form:ConditionalFieldGroup ;
+    mu:uuid "335b1a8a-e6d6-11ea-bf88-8b5df92c347a";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitDocumentType/3fa67785-ffdc-4b30-8880-2b99d97b4dee>
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuursorgaanClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000005> # gemeenteraad
+      ] ;
+    form:hasFieldGroup fieldGroups:7e26db7b-e864-4afe-ad2b-1753434f3e3f .fieldGroups:1455df6c-53b0-4d01-9d4b-8c5f2bc3832f a form:FieldGroup ;
+    mu:uuid "1455df6c-53b0-4d01-9d4b-8c5f2bc3832f" ;
+    form:hasField
+
+                      ###Links-naar-documenten###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,
+
+                      ###Bestanden###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95a.
+
+# this field is the custom bestuursorgaan selector
+fields:4c7820f0-4011-4ab4-a16a-e128800e11bc form:hasConditionalFieldGroup fields:cfe4b653-65ef-4a84-93bd-1dd1c2a60f59.
+
+fields:cfe4b653-65ef-4a84-93bd-1dd1c2a60f59 a form:ConditionalFieldGroup ;
+    mu:uuid "cfe4b653-65ef-4a84-93bd-1dd1c2a60f59";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitDocumentType/3fa67785-ffdc-4b30-8880-2b99d97b4dee>
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuursorgaanClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/180a2fba-6ca9-4766-9b94-82006bb9c709> # Gouverneur
+      ] ;
+    form:hasFieldGroup fieldGroups:1455df6c-53b0-4d01-9d4b-8c5f2bc3832f .fieldGroups:0b6c8596-8536-4726-bd93-137005d7aa5f a form:FieldGroup ;
+    mu:uuid "0b6c8596-8536-4726-bd93-137005d7aa5f" ;
+    form:hasField
+
+                      ###Links-naar-documenten###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,
+
+                      ###Bestanden###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95a.
+
+# this field is the custom bestuursorgaan selector
+fields:4c7820f0-4011-4ab4-a16a-e128800e11bc form:hasConditionalFieldGroup fields:6c7676ec-0b58-4f1d-b56e-c988834a0c31.
+
+fields:6c7676ec-0b58-4f1d-b56e-c988834a0c31 a form:ConditionalFieldGroup ;
+    mu:uuid "6c7676ec-0b58-4f1d-b56e-c988834a0c31";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitDocumentType/3fa67785-ffdc-4b30-8880-2b99d97b4dee>
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:bestuurt besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuurseenheidClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/ea446861-2c51-45fa-afd3-4e4a37b71562> # Hulpverleningszone
+      ] ;
+    form:hasFieldGroup fieldGroups:0b6c8596-8536-4726-bd93-137005d7aa5f .fieldGroups:617d86f7-321a-4b37-967a-333457cc1a80 a form:FieldGroup ;
+    mu:uuid "617d86f7-321a-4b37-967a-333457cc1a80" ;
+    form:hasField
+
+                      ###Links-naar-documenten###
+                      fields:1e0f541f-61e9-43a7-bc5f-612eb44f52bb,
+
+                      ###Bestanden###
+                      fields:c7c5a589-0785-4032-a4bd-ee589add3c39.
+
+# this field is the custom bestuursorgaan selector
+fields:4c7820f0-4011-4ab4-a16a-e128800e11bc form:hasConditionalFieldGroup fields:345911d9-48d0-4f4b-b261-8dc5ec4d4308.
+
+fields:345911d9-48d0-4f4b-b261-8dc5ec4d4308 a form:ConditionalFieldGroup ;
+    mu:uuid "345911d9-48d0-4f4b-b261-8dc5ec4d4308";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitDocumentType/3fa67785-ffdc-4b30-8880-2b99d97b4dee>
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuursorgaanClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000007> # Raad voor Maatschappelijk Welzijn
+      ] ;
+    form:hasFieldGroup fieldGroups:617d86f7-321a-4b37-967a-333457cc1a80 .fieldGroups:65bd1029-ec2a-4c4c-bc1d-d2ff2710908f a form:FieldGroup ;
+    mu:uuid "65bd1029-ec2a-4c4c-bc1d-d2ff2710908f" ;
+    form:hasField
+
+                      ###Links-naar-documenten###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,
+
+                      ###Bestanden###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95a.
+
+# this field is the custom bestuursorgaan selector
+fields:4c7820f0-4011-4ab4-a16a-e128800e11bc form:hasConditionalFieldGroup fields:a7af8717-bb21-4d4a-8d6a-7477ba0dc021.
+
+fields:a7af8717-bb21-4d4a-8d6a-7477ba0dc021 a form:ConditionalFieldGroup ;
+    mu:uuid "a7af8717-bb21-4d4a-8d6a-7477ba0dc021";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitDocumentType/3fa67785-ffdc-4b30-8880-2b99d97b4dee>
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:bestuurt besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuurseenheidClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> # Politiezone
+      ] ;
+    form:hasFieldGroup fieldGroups:65bd1029-ec2a-4c4c-bc1d-d2ff2710908f .fieldGroups:c4e06af8-7dde-405d-b273-a5fd47ac8f2f a form:FieldGroup ;
+    mu:uuid "c4e06af8-7dde-405d-b273-a5fd47ac8f2f" ;
+    form:hasField
+
+                      ###Links-naar-documenten###
+                      fields:1e0f541f-61e9-43a7-bc5f-612eb44f52bb,
+
+                      ###Bestanden###
+                      fields:c7c5a589-0785-4032-a4bd-ee589add3c39.
+
+# this field is the custom bestuursorgaan selector
+fields:4c7820f0-4011-4ab4-a16a-e128800e11bc form:hasConditionalFieldGroup fields:60ebd2aa-12c4-4f63-9155-113d789e6ccc.
+
+fields:60ebd2aa-12c4-4f63-9155-113d789e6ccc a form:ConditionalFieldGroup ;
+    mu:uuid "60ebd2aa-12c4-4f63-9155-113d789e6ccc";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitDocumentType/3fa67785-ffdc-4b30-8880-2b99d97b4dee>
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuursorgaanClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e00000c> # Provincieraad
+      ] ;
+    form:hasFieldGroup fieldGroups:c4e06af8-7dde-405d-b273-a5fd47ac8f2f .fieldGroups:c6913042-e84b-4ba9-a2f5-424b9cd5f005 a form:FieldGroup ;
+    mu:uuid "c6913042-e84b-4ba9-a2f5-424b9cd5f005" ;
+    form:hasField
+
+                      ###Links-naar-documenten###
+                      fields:1e0f541f-61e9-43a7-bc5f-612eb44f52bb,
+
+                      ###Bestanden###
+                      fields:c7c5a589-0785-4032-a4bd-ee589add3c39.
+
+# this field is the custom bestuursorgaan selector
+fields:4c7820f0-4011-4ab4-a16a-e128800e11bc form:hasConditionalFieldGroup fields:fc67c635-0ad3-4424-aaae-0b7c2cd4d814.
+
+fields:fc67c635-0ad3-4424-aaae-0b7c2cd4d814 a form:ConditionalFieldGroup ;
+    mu:uuid "fc67c635-0ad3-4424-aaae-0b7c2cd4d814";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitDocumentType/3fa67785-ffdc-4b30-8880-2b99d97b4dee>
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuursorgaanClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> # Raad van bestuur
+      ] ;
+    form:hasFieldGroup fieldGroups:c6913042-e84b-4ba9-a2f5-424b9cd5f005 .fieldGroups:4960cd98-f4ad-488f-8250-9fc0e63c696f a form:FieldGroup ;
+    mu:uuid "4960cd98-f4ad-488f-8250-9fc0e63c696f" ;
+    form:hasField
+
+                      ###Links-naar-documenten###
+                      fields:1e0f541f-61e9-43a7-bc5f-612eb44f52bb,
+
+                      ###Bestanden###
+                      fields:c7c5a589-0785-4032-a4bd-ee589add3c39.
+
+# this field is the custom bestuursorgaan selector
+fields:4c7820f0-4011-4ab4-a16a-e128800e11bc form:hasConditionalFieldGroup fields:d4c8b02f-815c-47d9-85af-ba7a7e42bd4e.
+
+fields:d4c8b02f-815c-47d9-85af-ba7a7e42bd4e a form:ConditionalFieldGroup ;
+    mu:uuid "d4c8b02f-815c-47d9-85af-ba7a7e42bd4e";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitDocumentType/3fa67785-ffdc-4b30-8880-2b99d97b4dee>
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuursorgaanClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/17e76b36-64a1-4db1-8927-def3064b4bf1> # Regionaal bestuurscomité
+      ] ;
+    form:hasFieldGroup fieldGroups:4960cd98-f4ad-488f-8250-9fc0e63c696f .fieldGroups:946669c2-f6eb-464d-a455-9633cc9a150c a form:FieldGroup ;
+    mu:uuid "946669c2-f6eb-464d-a455-9633cc9a150c" ;
+    form:hasField
+
+                      ###Links-naar-documenten###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,
+
+                      ###Bestanden###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95a.
+
+# this field is the custom bestuursorgaan selector
+fields:4c7820f0-4011-4ab4-a16a-e128800e11bc form:hasConditionalFieldGroup fields:7d110233-1584-49ac-9668-a1ee8c73744c.
+
+fields:7d110233-1584-49ac-9668-a1ee8c73744c a form:ConditionalFieldGroup ;
+    mu:uuid "7d110233-1584-49ac-9668-a1ee8c73744c";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitDocumentType/3fa67785-ffdc-4b30-8880-2b99d97b4dee>
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuursorgaanClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000008> # vast bureau
+      ] ;
+    form:hasFieldGroup fieldGroups:946669c2-f6eb-464d-a455-9633cc9a150c .fieldGroups:cd043d7a-175a-4453-88cb-a3083e57086d a form:FieldGroup ;
+    mu:uuid "cd043d7a-175a-4453-88cb-a3083e57086d" ;
+    form:hasField
+
+                      ###Links-naar-documenten###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,
+
+                      ###Bestanden###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95a.
+
+# this field is the custom bestuursorgaan selector
+fields:4c7820f0-4011-4ab4-a16a-e128800e11bc form:hasConditionalFieldGroup fields:3a3c7b25-cce7-4b69-9412-4e79ae0bccb8.
+
+fields:3a3c7b25-cce7-4b69-9412-4e79ae0bccb8 a form:ConditionalFieldGroup ;
+    mu:uuid "3a3c7b25-cce7-4b69-9412-4e79ae0bccb8";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitDocumentType/3fa67785-ffdc-4b30-8880-2b99d97b4dee>
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuursorgaanClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/53c0d8cd-f3a2-411d-bece-4bd83ae2bbc9> # Voorzitter van het Bijzonder Comité voor de Sociale Dienst
+      ] ;
+    form:hasFieldGroup fieldGroups:cd043d7a-175a-4453-88cb-a3083e57086d .###########VGC Bijzonder adminstratief toezicht###########
+
+fieldGroups:473b2370-fa80-41bf-8e0f-842d63093b5a a form:FieldGroup ;
+    mu:uuid "473b2370-fa80-41bf-8e0f-842d63093b5a" ;
+    form:hasField
+
+                      ###Datum-zitting/besluit###
+                      fields:3dd6ed93-40f7-4d70-a6cb-f4de53dc8bfb,
+
+                      ###Welk-beslissingsorgaan-nam-het-besluit?###
+                      fields:4c7820f0-4011-4ab4-a16a-e128800e11bc,
+
+                      ###Bestanden###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95a,
+
+                      ###Links-naar-documenten###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,
+
+                      ###Type RemoteDataObject or FileDataObject###
+                      fields:355fe001-cdca-48cc-8a6e-88b3aab09874,
+
+                      ### RemoteDataObject/url ###
+                      fields:d0052f0d-90bc-4543-a6b0-e90a1c1117db.
+
+fields:0827fafe-ad19-49e1-8b2e-105d2c08a54a form:hasConditionalFieldGroup fields:f038bf93-0f8b-46e4-a095-50dc10caae5a.
+
+fields:f038bf93-0f8b-46e4-a095-50dc10caae5a a form:ConditionalFieldGroup ;
+    mu:uuid "f038bf93-0f8b-46e4-a095-50dc10caae5a";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitDocumentType/d60eb90b-926b-4c64-b87c-866c0cf92f0a>
+      ] ;
+    form:hasFieldGroup fieldGroups:473b2370-fa80-41bf-8e0f-842d63093b5a .
+
+###########Budget-Eredienst###########
+
+fieldGroups:acabf4e0-a124-4d68-b3f1-f93e86c7b1e5 a form:FieldGroup ;
+    mu:uuid "acabf4e0-a124-4d68-b3f1-f93e86c7b1e5" ;
+    form:hasField
+                      ###Gaat-het-over-het-origineel-document-of-over-een-wijziging?-erediensten###
+                      fields:ea141dfa-80ff-4958-9493-c0cf6724cbf6,
+
+                      ###Links-naar-documenten###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,
+
+                      ###Bestanden (custom)###
+                      fields:7465c000-c844-4ba9-82cc-bd173cbe41a3.
+
+# this field is the custom bestuursorgaan selector
+fields:4c7820f0-4011-4ab4-a16a-e128800e11bc form:hasConditionalFieldGroup fields:29e7bd94-1aa4-4ad2-9b43-b7ececf46348.
+
+fields:29e7bd94-1aa4-4ad2-9b43-b7ececf46348 a form:ConditionalFieldGroup ;
+    mu:uuid "29e7bd94-1aa4-4ad2-9b43-b7ececf46348";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/40831a2c-771d-4b41-9720-0399998f1873> 
+      ],
+      [ a form:MatchValues ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:classificatie ) ;
+        form:valuesIn (
+            <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/04f65457bf125b2dc59fd71917ac3d08>
+            <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b475fa47e17a8a05ae04a9e1fb9c9258>
+            <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/90a9ec83cb93b9369bba7ff29d9ce5ce>
+            <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/a0701624aefb115b7eda2ff39139c2dd>
+            <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/af811edba97c6ec34874d0830cbb1183> );
+      ] ;
+    form:hasFieldGroup fieldGroups:acabf4e0-a124-4d68-b3f1-f93e86c7b1e5 .
+###########Budget-Root###########
+
+fieldGroups:8e826b62-3bce-4a9c-b8c1-e84db510c6a3 a form:FieldGroup ;
+    mu:uuid "8e826b62-3bce-4a9c-b8c1-e84db510c6a3" ; 
+    form:hasField 
+                      ###Rapportjaar###
+                      fields:41737f90-02d6-4036-8d60-5d5b6ccf939c,
+
+                      ###Datum-zitting/besluit###
+                      fields:3dd6ed93-40f7-4d70-a6cb-f4de53dc8bfb,
+
+                      ###Welk-beslissingsorgaan-nam-het-besluit?###
+                      fields:4c7820f0-4011-4ab4-a16a-e128800e11bc,
+
+                      ###Type RemoteDataObject or FileDataObject###
+                      fields:355fe001-cdca-48cc-8a6e-88b3aab09874,
+
+                      ### RemoteDataObject/url ###
+                      fields:d0052f0d-90bc-4543-a6b0-e90a1c1117db.
+
+fields:0827fafe-ad19-49e1-8b2e-105d2c08a54a form:hasConditionalFieldGroup fields:8640f3ff-2302-40eb-85c6-d932628250ed.
+
+fields:8640f3ff-2302-40eb-85c6-d932628250ed a form:ConditionalFieldGroup ;
+    mu:uuid "8640f3ff-2302-40eb-85c6-d932628250ed";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/40831a2c-771d-4b41-9720-0399998f1873>
+      ] ;
+    form:hasFieldGroup fieldGroups:8e826b62-3bce-4a9c-b8c1-e84db510c6a3 .
+
+
+
+###########Budget-General###########
+
+fieldGroups:5a3cbfb4-3ca5-4abb-a48d-c3e6c0efaf95 a form:FieldGroup ;
+    mu:uuid "5a3cbfb4-3ca5-4abb-a48d-c3e6c0efaf95" ;
+    form:hasField
+                    ###Gaat-het-over-het-origineel-document-of-over-een-wijziging?###
+                    fields:a8f6a6cb-dbb8-488c-878d-05603791a9eb,
+
+                    ###Datum-van-publicatie-op-webtoepassing###
+                    fields:49dbe1be-877a-4890-8465-1510ff18ce18,
+                    
+                    ###Links-naar-documenten###
+                    fields:1e0f541f-61e9-43a7-bc5f-612eb44f52bb,
+                    
+                    ###Bestanden###
+                    fields:c7c5a589-0785-4032-a4bd-ee589add3c39.
+
+# this field is the custom bestuursorgaan selector
+fields:4c7820f0-4011-4ab4-a16a-e128800e11bc form:hasConditionalFieldGroup fields:3aa3da45-d29b-4ad4-83c3-b2eb99b3b13f.
+
+fields:3aa3da45-d29b-4ad4-83c3-b2eb99b3b13f a form:ConditionalFieldGroup ;
+    mu:uuid "3aa3da45-d29b-4ad4-83c3-b2eb99b3b13f";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/40831a2c-771d-4b41-9720-0399998f1873>
+      ],
+      [ a form:MatchValues ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:classificatie ) ;
+        form:valuesNotIn (
+            <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/04f65457bf125b2dc59fd71917ac3d08>
+            <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b475fa47e17a8a05ae04a9e1fb9c9258>
+            <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/90a9ec83cb93b9369bba7ff29d9ce5ce>
+            <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/a0701624aefb115b7eda2ff39139c2dd>
+            <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/af811edba97c6ec34874d0830cbb1183> 
+             );
+      ] ;
+    form:hasFieldGroup fieldGroups:5a3cbfb4-3ca5-4abb-a48d-c3e6c0efaf95 .########### Code van goed bestuur ###########
+
+# Conditionally add the form fields to the "type dossier" field
+fields:0827fafe-ad19-49e1-8b2e-105d2c08a54a form:hasConditionalFieldGroup fields:515dc238-beb7-4888-9f7f-04cbdda5385e.
+
+# Only add the fields if the user selected the "Code van goed bestuur" option
+fields:515dc238-beb7-4888-9f7f-04cbdda5385e a form:ConditionalFieldGroup ;
+    mu:uuid "515dc238-beb7-4888-9f7f-04cbdda5385e";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/b04bc642-c892-4aae-ac1f-f6ff21362704>
+      ] ;
+    form:hasFieldGroup fieldGroups:0ec0bd00-3b93-4ccd-974c-dd18f99c877b .
+
+fieldGroups:0ec0bd00-3b93-4ccd-974c-dd18f99c877b a form:FieldGroup ;
+    mu:uuid "0ec0bd00-3b93-4ccd-974c-dd18f99c877b" ;
+
+    form:hasField
+      ### Welk-beslissingsorgaan-nam-het-besluit? ###
+      fields:4c7820f0-4011-4ab4-a16a-e128800e11bc,
+
+      ### Datum-zitting/besluit ###
+      fields:3dd6ed93-40f7-4d70-a6cb-f4de53dc8bfb,
+
+      ### Datum van publicatie op webtoepassing
+      fields:49dbe1be-877a-4890-8465-1510ff18ce18,
+
+      ### Links-naar-documenten ###
+      fields:1e0f541f-61e9-43a7-bc5f-612eb44f52bb ,
+
+      ### File uploader with custom help text
+      fields:a633a5bd-0ceb-4ead-8c53-27b7304100c5,
+
+      ###Type RemoteDataObject or FileDataObject###
+      fields:355fe001-cdca-48cc-8a6e-88b3aab09874,
+
+      ### RemoteDataObject/url ###
+      fields:d0052f0d-90bc-4543-a6b0-e90a1c1117db.
+
+############################################################################################
+# Custom form fields for the "Code van goed bestuur" form
+############################################################################################
+
+## File upload with custom help text
+fields:a633a5bd-0ceb-4ead-8c53-27b7304100c5 a form:Field ;
+    mu:uuid "a633a5bd-0ceb-4ead-8c53-27b7304100c5" ;
+    sh:name "Bestanden" ;
+    sh:order 10001 ;
+    sh:path dct:hasPart;
+    form:displayType displayTypes:files; # consider this v1.0
+    form:help """
+    <div class="au-c-content au-c-content--tiny">
+      <p>
+        Nadat de code van goed bestuur is goedgekeurd door de algemene vergadering, moet hij gepubliceerd worden
+        op de website van de vereniging binnen 10 dagen nadat het besluit genomen is (art. 467, eerste lid, 3° DLB).
+      </p>
+      <p>
+        Op dezelfde dag als deze publicatie op uw website, moet u hier een melding maken dat u de code hebt gepubliceerd,
+        met daarbij een link naar uw eigen website waar de code gepubliceerd is. Door het hier opladen van de link
+        van de code op uw website, voldoet u automatisch ook aan de mededelingsplicht van art. 434, §5 DLB.
+      </p>
+    </div>""" ;
+    sh:group fields:aDynamicPropertyGroup .
+########### Collectieve motie van wantrouwen ###########
+
+# Conditionally add the form fields to the "type dossier" field
+fields:0827fafe-ad19-49e1-8b2e-105d2c08a54a form:hasConditionalFieldGroup fields:5e1e0aa7-564a-4191-a7bf-f30b68311126.
+
+# Only add the fields if the user selected the "Collective motie van wantrouwen" option
+fields:5e1e0aa7-564a-4191-a7bf-f30b68311126 a form:ConditionalFieldGroup ;
+    mu:uuid "5e1e0aa7-564a-4191-a7bf-f30b68311126";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/cb361927-1aab-4016-bd8a-1a84841391ba>
+      ] ;
+    form:hasFieldGroup fieldGroups:ce41b18d-680d-4747-8f76-1ef4a1efea37 .
+
+fieldGroups:ce41b18d-680d-4747-8f76-1ef4a1efea37 a form:FieldGroup ;
+    mu:uuid "ce41b18d-680d-4747-8f76-1ef4a1efea37" ;
+
+    form:hasField
+      ### Welk-beslissingsorgaan-nam-het-besluit? ###
+      fields:4c7820f0-4011-4ab4-a16a-e128800e11bc,
+
+      ### Datum-zitting/besluit ###
+      fields:3dd6ed93-40f7-4d70-a6cb-f4de53dc8bfb,
+
+      ### Links-naar-documenten ###
+      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b ,
+
+      ### File uploader with custom help text
+      fields:d67e38fb-e68e-4b57-9622-b3017e81feaa,
+
+      ###Type RemoteDataObject or FileDataObject###
+      fields:355fe001-cdca-48cc-8a6e-88b3aab09874,
+
+      ### RemoteDataObject/url ###
+      fields:d0052f0d-90bc-4543-a6b0-e90a1c1117db.
+
+############################################################################################
+# Custom form fields for the "Collectieve motie van wantrouwen" form
+############################################################################################
+
+## File upload with custom help text
+fields:d67e38fb-e68e-4b57-9622-b3017e81feaa a form:Field ;
+    mu:uuid "d67e38fb-e68e-4b57-9622-b3017e81feaa" ;
+    sh:name "Bestanden" ;
+    sh:order 10001 ;
+    sh:path dct:hasPart;
+    form:validations
+     [ a  form:RequiredConstraint ;
+          form:grouping form:Bag ;
+          sh:path dct:hasPart;
+          sh:resultMessage "Gelieve minstens één URL of bestand op te geven."@nl # TODO: later custom validator
+     ];
+    form:displayType displayTypes:files; # consider this v1.0
+    form:help """Indien een collectieve motie van wantrouwen wordt aangenomen, moet u hier de ingediende collectieve motie en de beslissing van de gemeenteraad (of districtsraad) hierover opladen, dit is de kennisgeving zoals bepaald in artikel 46, §5 (of artikel 124/1, §5) van het DLB.""" ;
+    sh:group fields:aDynamicPropertyGroup .
+###########Onvoorziene kosten###########
+
+fieldGroups:9f364ec1-bb5f-4b7d-9dea-b0341bc5d5bc a form:FieldGroup ;
+    mu:uuid "9f364ec1-bb5f-4b7d-9dea-b0341bc5d5bc" ;
+    form:hasField
+                      ###Datum-zitting/besluit###
+                      fields:3dd6ed93-40f7-4d70-a6cb-f4de53dc8bfb,
+
+                      ###Welk-beslissingsorgaan-nam-het-besluit?###
+                      fields:bffbea8d-e55b-4e3d-86e8-ba7aaee7863d,
+
+                      ###Links-naar-documenten###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,
+
+                      ###Bestanden###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95a,
+
+                      ###Type RemoteDataObject or FileDataObject###
+                      fields:355fe001-cdca-48cc-8a6e-88b3aab09874,
+
+                      ### RemoteDataObject/url ###
+                      fields:d0052f0d-90bc-4543-a6b0-e90a1c1117db.
+
+fields:0827fafe-ad19-49e1-8b2e-105d2c08a54a form:hasConditionalFieldGroup fields:0dd4d0db-db4d-4e9a-8588-ea2082b65746.
+
+fields:0dd4d0db-db4d-4e9a-8588-ea2082b65746 a form:ConditionalFieldGroup ;
+    mu:uuid "0dd4d0db-db4d-4e9a-8588-ea2082b65746";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/52ce88b7-5608-4844-997d-d3a92d8cca69>
+      ] ;
+    form:hasFieldGroup fieldGroups:9f364ec1-bb5f-4b7d-9dea-b0341bc5d5bc .
+
+###########Eindrekening###########
+
+fieldGroups:393c7c2d-4e57-4bf7-89ae-21c05be7b5ed a form:FieldGroup ;
+    mu:uuid "393c7c2d-4e57-4bf7-89ae-21c05be7b5ed" ; 
+    form:hasField 
+                      ###Welk-beslissingsorgaan-nam-het-besluit?###
+                      fields:4c7820f0-4011-4ab4-a16a-e128800e11bc,
+                      
+                      ###Datum-zitting/besluit###
+                      fields:3dd6ed93-40f7-4d70-a6cb-f4de53dc8bfb,
+                      
+                      ###Links-naar-documenten###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,
+
+                      ###Bestanden (custom)###
+                      fields:e5aa62e8-08b7-4216-8b9c-5fea766e9a22,
+
+                      ###Type RemoteDataObject or FileDataObject###
+                      fields:355fe001-cdca-48cc-8a6e-88b3aab09874,
+
+                      ### RemoteDataObject/url ###
+                      fields:d0052f0d-90bc-4543-a6b0-e90a1c1117db.
+
+fields:0827fafe-ad19-49e1-8b2e-105d2c08a54a form:hasConditionalFieldGroup fields:16c8da54-4961-4282-b5c9-9cbd45eccba0.
+
+fields:16c8da54-4961-4282-b5c9-9cbd45eccba0 a form:ConditionalFieldGroup ;
+    mu:uuid "16c8da54-4961-4282-b5c9-9cbd45eccba0";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/54b61cbd-349f-41c4-9c8a-7e8e67d08347>
+      ] ;
+    form:hasFieldGroup fieldGroups:393c7c2d-4e57-4bf7-89ae-21c05be7b5ed .
+###########Gecoordineerde-inzending-budgetten###########
+
+fieldGroups:aaf4f9b2-643f-474d-b1b0-24f37784e5a6 a form:FieldGroup ;
+    mu:uuid "aaf4f9b2-643f-474d-b1b0-24f37784e5a6" ;
+    form:hasField
+
+                      ###Gaat-het-over-het-origineel-document-of-over-een-wijziging?-erediensten###
+                      fields:ea141dfa-80ff-4958-9493-c0cf6724cbf6,
+
+                      ###Rapportjaar###
+                      fields:41737f90-02d6-4036-8d60-5d5b6ccf939c,
+
+                      ###Links-naar-documenten###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,
+
+                      ###Bestanden (custom)###
+                      fields:9dd53fc5-077b-439c-aad9-5530f95083e8,
+
+                      ###Type RemoteDataObject or FileDataObject###
+                      fields:355fe001-cdca-48cc-8a6e-88b3aab09874,
+
+                      ###Related decision [hidden]###
+                      fields:c0f621fc-4c2c-456b-83f9-f087e64af03a,
+
+                      ### RemoteDataObject/url ###
+                      fields:d0052f0d-90bc-4543-a6b0-e90a1c1117db.
+
+fields:0827fafe-ad19-49e1-8b2e-105d2c08a54a form:hasConditionalFieldGroup fields:7a09cedf-cfa9-4513-ae75-83c650e854b5.
+
+fields:7a09cedf-cfa9-4513-ae75-83c650e854b5 a form:ConditionalFieldGroup ;
+    mu:uuid "7a09cedf-cfa9-4513-ae75-83c650e854b5";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitDocumentType/18833df2-8c9e-4edd-87fd-b5c252337349>
+      ] ;
+    form:hasFieldGroup fieldGroups:aaf4f9b2-643f-474d-b1b0-24f37784e5a6 .
+###########Gecoordineerde-inzending-meerjarenplannen###########
+
+fieldGroups:bef0fd9f-5f60-4e68-b8d7-1b515cc3ccc2 a form:FieldGroup ;
+    mu:uuid "bef0fd9f-5f60-4e68-b8d7-1b515cc3ccc2" ;
+    form:hasField
+
+                      ###Gaat-het-over-het-origineel-document-of-over-een-wijziging?-erediensten###
+                      fields:ea141dfa-80ff-4958-9493-c0cf6724cbf6,
+
+                      ###Rapportperiode###
+                      fields:e578e3ff-240b-421b-a32c-f411489c3806,
+
+                      ###Links-naar-documenten###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,
+
+                      ###Bestanden (custom)###
+                      fields:c34a860a-a82e-482d-b077-6482a4edfe3f,
+
+                      ###Type RemoteDataObject or FileDataObject###
+                      fields:355fe001-cdca-48cc-8a6e-88b3aab09874,
+
+                      ###Related decision [hidden]###
+                      fields:c0f621fc-4c2c-456b-83f9-f087e64af03a,
+                      
+                      ### RemoteDataObject/url ###
+                      fields:d0052f0d-90bc-4543-a6b0-e90a1c1117db.
+
+fields:0827fafe-ad19-49e1-8b2e-105d2c08a54a form:hasConditionalFieldGroup fields:41cd1378-5f16-48a5-92cb-7f4caf89ff16.
+
+fields:41cd1378-5f16-48a5-92cb-7f4caf89ff16 a form:ConditionalFieldGroup ;
+    mu:uuid "41cd1378-5f16-48a5-92cb-7f4caf89ff16";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitDocumentType/2c9ada23-1229-4c7e-a53e-acddc9014e4e>
+      ] ;
+    form:hasFieldGroup fieldGroups:bef0fd9f-5f60-4e68-b8d7-1b515cc3ccc2 .
+###########Gezamenlijke-inzending-jaarrekeningen###########
+
+fieldGroups:40fa78b5-4e89-47c0-99cb-a8e936a09d19 a form:FieldGroup ;
+    mu:uuid "40fa78b5-4e89-47c0-99cb-a8e936a09d19" ;
+    form:hasField
+                      ###Rapportjaar###
+                      fields:41737f90-02d6-4036-8d60-5d5b6ccf939c,
+
+                      ###Links-naar-documenten###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,
+
+                      ###Bestanden (custom)###
+                      fields:48cff9eb-579b-4e6e-958f-6229903c63d8,
+
+                      ###Type RemoteDataObject or FileDataObject###
+                      fields:355fe001-cdca-48cc-8a6e-88b3aab09874,
+
+                      ###Related decision [hidden]###
+                      fields:c0f621fc-4c2c-456b-83f9-f087e64af03a,
+
+                      ### RemoteDataObject/url ###
+                      fields:d0052f0d-90bc-4543-a6b0-e90a1c1117db.
+
+fields:0827fafe-ad19-49e1-8b2e-105d2c08a54a form:hasConditionalFieldGroup fields:e3b81b82-78cb-4631-884d-ef9f135ab646.
+
+fields:e3b81b82-78cb-4631-884d-ef9f135ab646 a form:ConditionalFieldGroup ;
+    mu:uuid "e3b81b82-78cb-4631-884d-ef9f135ab646";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitDocumentType/672bf096-dccd-40af-ab60-bd7de15cc461>
+      ] ;
+    form:hasFieldGroup fieldGroups:40fa78b5-4e89-47c0-99cb-a8e936a09d19 .
+
+
+###########Goedkeuringstoezicht-Voeren###########
+
+fieldGroups:7e841b1c-64a4-48a6-b39d-c18fe1a9394f a form:FieldGroup ;
+    mu:uuid "7e841b1c-64a4-48a6-b39d-c18fe1a9394f" ; 
+    form:hasField 
+                      ###Welk-beslissingsorgaan-nam-het-besluit?###
+                      fields:bffbea8d-e55b-4e3d-86e8-ba7aaee7863d,
+
+                      ###Datum-zitting/besluit###
+                      fields:3dd6ed93-40f7-4d70-a6cb-f4de53dc8bfb,
+
+                      ###Dossieromschrijving###
+                      fields:bd6ee5ac-22d6-4279-bcba-3ed279021aac,
+
+                      ###Links-naar-documenten###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,
+
+                      ###Bestanden###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95a,
+
+                      ###Type RemoteDataObject or FileDataObject###
+                      fields:355fe001-cdca-48cc-8a6e-88b3aab09874,
+
+                      ### RemoteDataObject/url ###
+                      fields:d0052f0d-90bc-4543-a6b0-e90a1c1117db.
+                      
+fields:0827fafe-ad19-49e1-8b2e-105d2c08a54a form:hasConditionalFieldGroup fields:e929ed9d-3a37-4bf1-9b6c-d8285fa0ec0c.
+
+fields:e929ed9d-3a37-4bf1-9b6c-d8285fa0ec0c a form:ConditionalFieldGroup ;
+    mu:uuid "e929ed9d-3a37-4bf1-9b6c-d8285fa0ec0c";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/6af621e2-c807-479e-a6f2-2d64d8339491>
+      ] ;
+    form:hasFieldGroup fieldGroups:7e841b1c-64a4-48a6-b39d-c18fe1a9394f .
+
+###########Herschikking lening###########
+
+fieldGroups:4204ee5d-e606-4f97-8142-906e064f5e54 a form:FieldGroup ;
+    mu:uuid "4204ee5d-e606-4f97-8142-906e064f5e54" ;
+    form:hasField
+                      ###Datum-zitting/besluit###
+                      fields:3dd6ed93-40f7-4d70-a6cb-f4de53dc8bfb,
+
+                      ###Welk-beslissingsorgaan-nam-het-besluit?###
+                      fields:bffbea8d-e55b-4e3d-86e8-ba7aaee7863d,
+
+                      ###Links-naar-documenten###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,
+
+                      ###Bestanden###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95a,
+
+                      ###Type RemoteDataObject or FileDataObject###
+                      fields:355fe001-cdca-48cc-8a6e-88b3aab09874,
+
+                      ### RemoteDataObject/url ###
+                      fields:d0052f0d-90bc-4543-a6b0-e90a1c1117db.
+
+fields:0827fafe-ad19-49e1-8b2e-105d2c08a54a form:hasConditionalFieldGroup fields:3a012f11-9a18-48ba-b8d5-cef8b13bb42b.
+
+fields:3a012f11-9a18-48ba-b8d5-cef8b13bb42b a form:ConditionalFieldGroup ;
+    mu:uuid "3a012f11-9a18-48ba-b8d5-cef8b13bb42b";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/3b39de52-ba57-4c29-a41f-3ad65c2fae24>
+      ] ;
+    form:hasFieldGroup fieldGroups:4204ee5d-e606-4f97-8142-906e064f5e54 .
+
+###########Jaarrekening-Eredienst###########
+
+fieldGroups:7d12a2bd-30f3-4e1e-8cb5-3c274c021d12 a form:FieldGroup ;
+    mu:uuid "7d12a2bd-30f3-4e1e-8cb5-3c274c021d12" ; 
+    form:hasField 
+                      ###Links-naar-documenten###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,
+
+                      ###Bestanden (custom)###
+                      fields:d0555b84-9d8c-4ca8-b7f2-a3bee96bd82f.
+
+# this field is the custom bestuursorgaan selector
+fields:4c7820f0-4011-4ab4-a16a-e128800e11bc  form:hasConditionalFieldGroup fields:13939a6c-2354-4a87-8d45-420ce6421140.
+
+fields:13939a6c-2354-4a87-8d45-420ce6421140 a form:ConditionalFieldGroup ;
+    mu:uuid "13939a6c-2354-4a87-8d45-420ce6421140";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/e44c535d-4339-4d15-bdbf-d4be6046de2c>
+      ],
+      [ a form:MatchValues ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:classificatie ) ;
+        form:valuesIn (
+            <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/04f65457bf125b2dc59fd71917ac3d08>
+            <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b475fa47e17a8a05ae04a9e1fb9c9258>
+            <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/90a9ec83cb93b9369bba7ff29d9ce5ce>
+            <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/a0701624aefb115b7eda2ff39139c2dd>
+            <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/af811edba97c6ec34874d0830cbb1183> );
+      ] ;
+    form:hasFieldGroup fieldGroups:7d12a2bd-30f3-4e1e-8cb5-3c274c021d12 .
+
+
+###########Jaarrekening-Root###########
+
+fieldGroups:7d5f1a08-598c-4a67-a102-a8bc07ac2f13 a form:FieldGroup ;
+    mu:uuid "7d5f1a08-598c-4a67-a102-a8bc07ac2f13" ; 
+    form:hasField 
+
+                      ###Datum-zitting/besluit###
+                      fields:3dd6ed93-40f7-4d70-a6cb-f4de53dc8bfb,
+
+                      ###Rapportjaar###
+                      fields:41737f90-02d6-4036-8d60-5d5b6ccf939c,
+
+                      ###Welk-beslissingsorgaan-nam-het-besluit?###
+                      fields:4c7820f0-4011-4ab4-a16a-e128800e11bc,
+
+                      ###Type RemoteDataObject or FileDataObject###
+                      fields:355fe001-cdca-48cc-8a6e-88b3aab09874,
+
+                      ### RemoteDataObject/url ###
+                      fields:d0052f0d-90bc-4543-a6b0-e90a1c1117db.
+
+fields:0827fafe-ad19-49e1-8b2e-105d2c08a54a form:hasConditionalFieldGroup fields:887f0b61-cbb6-41a9-a4d3-62d980760aa6.
+
+fields:887f0b61-cbb6-41a9-a4d3-62d980760aa6 a form:ConditionalFieldGroup ;
+    mu:uuid "887f0b61-cbb6-41a9-a4d3-62d980760aa6";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/e44c535d-4339-4d15-bdbf-d4be6046de2c>
+      ] ;
+    form:hasFieldGroup fieldGroups:7d5f1a08-598c-4a67-a102-a8bc07ac2f13 .
+
+
+###########Jaarrekening-General###########
+
+fieldGroups:f56fa353-5ad9-423f-8804-c32d104873e5 a form:FieldGroup ;
+    mu:uuid "f56fa353-5ad9-423f-8804-c32d104873e5" ; 
+    form:hasField 
+                    
+                      ###Datum-van-publicatie-op-webtoepassing###
+                      fields:49dbe1be-877a-4890-8465-1510ff18ce18,
+
+                      ###Links-naar-documenten###
+                      fields:1e0f541f-61e9-43a7-bc5f-612eb44f52bb,
+
+                      ###Bestanden###
+                      fields:c7c5a589-0785-4032-a4bd-ee589add3c39.
+
+
+# this field is the custom bestuursorgaan selector
+fields:4c7820f0-4011-4ab4-a16a-e128800e11bc  form:hasConditionalFieldGroup fields:5d0edb7c-3676-42cc-bd54-7f5712ec0b06.
+
+fields:5d0edb7c-3676-42cc-bd54-7f5712ec0b06 a form:ConditionalFieldGroup ;
+    mu:uuid "5d0edb7c-3676-42cc-bd54-7f5712ec0b06";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/e44c535d-4339-4d15-bdbf-d4be6046de2c>
+      ],
+      [ a form:MatchValues ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:classificatie ) ;
+        form:valuesNotIn (
+            <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/04f65457bf125b2dc59fd71917ac3d08>
+            <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b475fa47e17a8a05ae04a9e1fb9c9258>
+            <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/90a9ec83cb93b9369bba7ff29d9ce5ce>
+            <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/a0701624aefb115b7eda2ff39139c2dd>
+            <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/af811edba97c6ec34874d0830cbb1183> );
+      ] ;
+    form:hasFieldGroup fieldGroups:f56fa353-5ad9-423f-8804-c32d104873e5 .
+
+###########LEKP-Rapport Klimaattafels###########
+
+fieldGroups:b1143874-884d-4ffd-8d69-97383870a42e a form:FieldGroup ;
+    mu:uuid "b1143874-884d-4ffd-8d69-97383870a42e" ; 
+    form:hasField 
+                      ### Infolabel 
+                      fields:2bb6c63d-2cb7-4e82-839f-5c1e0a4f6a5e,
+                      
+                      ### climateTable Date
+                      fields:2bc38df5-dc28-4d4d-a6e1-b6d95644c8d7,
+
+                      ### Households
+                      fields:28ddce67-6aaf-4a3b-8953-63eeb7178d1f,
+
+                      ### Links
+                      fields:df63b483-f2ee-4274-a7d0-0cfc916d22ce,
+
+                      ### RemoteDataObject/url ###
+                      fields:355fe001-cdca-48cc-8a6e-88b3aab09874,
+                      fields:d0052f0d-90bc-4543-a6b0-e90a1c1117db.
+
+fields:0827fafe-ad19-49e1-8b2e-105d2c08a54a form:hasConditionalFieldGroup fields:a8ab356d-9d3b-46f1-8de6-9f2f1b9ec424 .
+
+fields:a8ab356d-9d3b-46f1-8de6-9f2f1b9ec424 a form:ConditionalFieldGroup ;
+    mu:uuid "a8ab356d-9d3b-46f1-8de6-9f2f1b9ec424";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitDocumentType/1d14cb62-7e57-44a9-ad20-2b08407fbb84>
+      ] ;
+    form:hasFieldGroup fieldGroups:b1143874-884d-4ffd-8d69-97383870a42e .###########LEKP-Rapport melding correctie authentieke bron###########
+
+fieldGroups:da491d56-4f98-4f9d-8c34-71ba617cfa64 a form:FieldGroup ;
+    mu:uuid "da491d56-4f98-4f9d-8c34-71ba617cfa64" ; 
+    form:hasField 
+
+                      ### Infolabel 
+                      fields:2bb6c63d-2cb7-4e82-839f-5c1e0a4f6a5e,
+                      
+                      ### Authentieke bron
+                      fields:7ebdf368-fe63-45d7-9d44-030ec0cd9ab9,
+
+                      ### Type Correctie
+                      fields:40c91f8e-be26-4e7d-8920-ae547f143744,
+
+                      ### Omschrijving
+                      fields:5a52adff-2558-437e-8a30-132648f4870c,
+
+                      ###Bestanden
+                      fields:f7e4b0a8-e970-4d49-a6d0-16c99a761f17,
+
+                      ###Type RemoteDataObject or FileDataObject###
+                      fields:355fe001-cdca-48cc-8a6e-88b3aab09874.
+
+fields:0827fafe-ad19-49e1-8b2e-105d2c08a54a form:hasConditionalFieldGroup fields:6e4101e4-3eae-4e56-ad3e-d9897248d17c.
+
+fields:6e4101e4-3eae-4e56-ad3e-d9897248d17c a form:ConditionalFieldGroup ;
+    mu:uuid "6e4101e4-3eae-4e56-ad3e-d9897248d17c";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitDocumentType/bea3944f-4f6d-4d2c-9a6e-23264859e1e5>
+      ] ;
+    form:hasFieldGroup fieldGroups:da491d56-4f98-4f9d-8c34-71ba617cfa64 .###########LEKP-Rapport Toelichting lokaal bestuur###########
+
+fieldGroups:ed8260d7-6150-490f-a3df-afba07ae7014 a form:FieldGroup ;
+    mu:uuid "ed8260d7-6150-490f-a3df-afba07ae7014" ; 
+    form:hasField 
+                      ### Infolabel 
+                      fields:2bb6c63d-2cb7-4e82-839f-5c1e0a4f6a5e,
+                      
+                      ### doelstelling
+                      fields:b2813526-d400-4cba-bdc4-bf64b2e21a80,
+
+                      ### Type toelichting
+                      fields:746e3820-c8db-478b-85d0-d238c6a531ea,
+
+                      ### Toelichting
+                      fields:8b8c8dc0-a728-42c6-837a-3b625d219140,
+
+                      ###Meer info
+                      fields:fa96567b-6677-4502-add5-f41e24dfee15 .
+
+fields:0827fafe-ad19-49e1-8b2e-105d2c08a54a form:hasConditionalFieldGroup fields:13d3b910-f486-4c8d-b76d-3d32e3fa6458.
+
+fields:13d3b910-f486-4c8d-b76d-3d32e3fa6458 a form:ConditionalFieldGroup ;
+    mu:uuid "13d3b910-f486-4c8d-b76d-3d32e3fa6458";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitDocumentType/91b8b15f-7631-4a21-9a90-489f5c91e73c>
+      ] ;
+    form:hasFieldGroup fieldGroups:ed8260d7-6150-490f-a3df-afba07ae7014 .
+###########Meerjarenplan(aanpassing)-Eredienst###########
+
+fieldGroups:5a21ed58-c0cf-4042-8b59-bd14ca595aae a form:FieldGroup ;
+    mu:uuid "5a21ed58-c0cf-4042-8b59-bd14ca595aae" ;
+    form:hasField
+                      ###Rapportperiode###
+                      fields:e578e3ff-240b-421b-a32c-f411489c3806,
+                      
+                      ###Gaat-het-over-het-origineel-document-of-over-een-wijziging?-erediensten###
+                      fields:ea141dfa-80ff-4958-9493-c0cf6724cbf6,
+
+                      ###Links-naar-documenten###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,
+
+                      ###Bestanden (CUSTOM) ###
+                      fields:95c9236e-e849-4888-82ae-b812f906e75d.
+
+# this field is the custom bestuursorgaan selector
+fields:4c7820f0-4011-4ab4-a16a-e128800e11bc form:hasConditionalFieldGroup fields:13a56126-4b73-4d92-a5d2-ddb2433f191b.
+
+fields:13a56126-4b73-4d92-a5d2-ddb2433f191b a form:ConditionalFieldGroup ;
+    mu:uuid "13a56126-4b73-4d92-a5d2-ddb2433f191b";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/f56c645d-b8e1-4066-813d-e213f5bc529f>
+      ],
+      [ a form:MatchValues ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:classificatie ) ;
+        form:valuesIn (
+            <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/04f65457bf125b2dc59fd71917ac3d08>
+            <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b475fa47e17a8a05ae04a9e1fb9c9258>
+            <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/90a9ec83cb93b9369bba7ff29d9ce5ce>
+            <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/a0701624aefb115b7eda2ff39139c2dd>
+            <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/af811edba97c6ec34874d0830cbb1183> );
+      ] ;
+    form:hasFieldGroup fieldGroups:5a21ed58-c0cf-4042-8b59-bd14ca595aae .
+
+
+
+
+
+
+###########Meerjarenplan(aanpassing)-Root###########
+
+fieldGroups:e0925be1-bdce-4890-b6e4-4f7640700581 a form:FieldGroup ;
+    mu:uuid "e0925be1-bdce-4890-b6e4-4f7640700581" ; 
+    form:hasField 
+                      ###Datum-zitting/besluit###
+                      fields:3dd6ed93-40f7-4d70-a6cb-f4de53dc8bfb,
+
+                      ###Welk-beslissingsorgaan-nam-het-besluit?###
+                      fields:4c7820f0-4011-4ab4-a16a-e128800e11bc,
+
+                      ###Type RemoteDataObject or FileDataObject###
+                      fields:355fe001-cdca-48cc-8a6e-88b3aab09874,
+
+                      ### RemoteDataObject/url ###
+                      fields:d0052f0d-90bc-4543-a6b0-e90a1c1117db.
+
+fields:0827fafe-ad19-49e1-8b2e-105d2c08a54a form:hasConditionalFieldGroup fields:8ba3d4c6-022e-401f-a47f-847b1220f669.
+
+fields:8ba3d4c6-022e-401f-a47f-847b1220f669 a form:ConditionalFieldGroup ;
+    mu:uuid "8ba3d4c6-022e-401f-a47f-847b1220f669";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/f56c645d-b8e1-4066-813d-e213f5bc529f>
+      ] ;
+    form:hasFieldGroup fieldGroups:e0925be1-bdce-4890-b6e4-4f7640700581 .
+
+
+###########Meerjarenplan(aanpassing)-General###########
+
+fieldGroups:978fd72b-26df-438e-8bf0-5dd661b191d5 a form:FieldGroup ;
+    mu:uuid "978fd72b-26df-438e-8bf0-5dd661b191d5" ;
+    form:hasField
+                    ###Rapportjaar###
+                    fields:41737f90-02d6-4036-8d60-5d5b6ccf939c,
+
+                    ###Gaat-het-over-het-origineel-document-of-over-een-wijziging?###
+                    fields:a8f6a6cb-dbb8-488c-878d-05603791a9eb,
+                    
+                    ###Datum-van-publicatie-op-webtoepassing###
+                    fields:49dbe1be-877a-4890-8465-1510ff18ce18,
+                    
+                    ###Links-naar-documenten###
+                    fields:1e0f541f-61e9-43a7-bc5f-612eb44f52bb,
+                    
+                    ###Bestanden###
+                    fields:c7c5a589-0785-4032-a4bd-ee589add3c39.
+
+# this field is the custom bestuursorgaan selector
+fields:4c7820f0-4011-4ab4-a16a-e128800e11bc form:hasConditionalFieldGroup fields:8a4f42d4-8f18-41c8-ac9b-76d327ba0df5.
+
+fields:8a4f42d4-8f18-41c8-ac9b-76d327ba0df5 a form:ConditionalFieldGroup ;
+    mu:uuid "8a4f42d4-8f18-41c8-ac9b-76d327ba0df5";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/f56c645d-b8e1-4066-813d-e213f5bc529f>
+      ],
+      [ a form:MatchValues ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:classificatie ) ;
+        form:valuesNotIn (
+            <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/04f65457bf125b2dc59fd71917ac3d08>
+            <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b475fa47e17a8a05ae04a9e1fb9c9258>
+            <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/90a9ec83cb93b9369bba7ff29d9ce5ce>
+            <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/a0701624aefb115b7eda2ff39139c2dd>
+            <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/af811edba97c6ec34874d0830cbb1183> 
+             );
+      ] ;
+    form:hasFieldGroup fieldGroups:978fd72b-26df-438e-8bf0-5dd661b191d5 .                      
+
+###########Meerjarenplan(aanpassing)-BBC2020###########
+
+fieldGroups:25818169-35e6-4798-bb78-c9bc4ea894d8 a form:FieldGroup ;
+    mu:uuid "25818169-35e6-4798-bb78-c9bc4ea894d8" ; 
+    form:hasField 
+                      ###Datum-van-publicatie-op-webtoepassing###
+                      fields:49dbe1be-877a-4890-8465-1510ff18ce18,
+
+                      ###Gaat-het-over-het-origineel-document-of-over-een-wijziging?###
+                      fields:a8f6a6cb-dbb8-488c-878d-05603791a9eb,
+
+                      ###Rapportjaar###
+                      fields:41737f90-02d6-4036-8d60-5d5b6ccf939c,
+
+                      ###Datum-zitting/besluit###
+                      fields:3dd6ed93-40f7-4d70-a6cb-f4de53dc8bfb,
+
+                      ###Datum-zitting/besluit###
+                      fields:3dd6ed93-40f7-4d70-a6cb-f4de53dc8bfb,
+
+                      ###Gaat-het-over-het-origineel-document-of-over-een-wijziging?###
+                      fields:a8f6a6cb-dbb8-488c-878d-05603791a9eb,
+
+                      ###Rapportjaar###
+                      fields:41737f90-02d6-4036-8d60-5d5b6ccf939c,
+
+                      ###Welk-beslissingsorgaan-nam-het-besluit?###
+                      fields:4c7820f0-4011-4ab4-a16a-e128800e11bc,
+
+                      ###Links-naar-documenten###
+                      fields:1e0f541f-61e9-43a7-bc5f-612eb44f52bb,
+
+                      ###Bestanden###
+                      fields:c7c5a589-0785-4032-a4bd-ee589add3c39,
+
+                      ###Type RemoteDataObject or FileDataObject###
+                      fields:355fe001-cdca-48cc-8a6e-88b3aab09874,
+
+                      ### RemoteDataObject/url ###
+                      fields:d0052f0d-90bc-4543-a6b0-e90a1c1117db.
+
+fields:0827fafe-ad19-49e1-8b2e-105d2c08a54a form:hasConditionalFieldGroup fields:66d433ec-7022-420b-8bf8-e718a8ecb795.
+
+fields:66d433ec-7022-420b-8bf8-e718a8ecb795 a form:ConditionalFieldGroup ;
+    mu:uuid "66d433ec-7022-420b-8bf8-e718a8ecb795";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/2f189152-1786-4b55-a3a9-d7f06de63f1c>
+      ] ;
+    form:hasFieldGroup fieldGroups:25818169-35e6-4798-bb78-c9bc4ea894d8 .
+
+###########Meerjarenplan aanpassing ocmwv###########
+
+fieldGroups:5f0ae173-ef30-445a-8411-5eee51fe1910 a form:FieldGroup ;
+    mu:uuid "5f0ae173-ef30-445a-8411-5eee51fe1910" ;
+    form:hasField
+                      ###Datum-zitting/besluit###
+                      fields:3dd6ed93-40f7-4d70-a6cb-f4de53dc8bfb,
+
+                      ###Welk-beslissingsorgaan-nam-het-besluit?###
+                      fields:bffbea8d-e55b-4e3d-86e8-ba7aaee7863d,
+
+                      ###Links-naar-documenten###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,
+
+                      ###Bestanden###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95a,
+
+                      ###Type RemoteDataObject or FileDataObject###
+                      fields:355fe001-cdca-48cc-8a6e-88b3aab09874,
+
+                      ### RemoteDataObject/url ###
+                      fields:d0052f0d-90bc-4543-a6b0-e90a1c1117db.
+
+fields:0827fafe-ad19-49e1-8b2e-105d2c08a54a form:hasConditionalFieldGroup fields:205c1db4-f132-4e82-b707-48f703ac0d86.
+
+fields:205c1db4-f132-4e82-b707-48f703ac0d86 a form:ConditionalFieldGroup ;
+    mu:uuid "205c1db4-f132-4e82-b707-48f703ac0d86";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/a7ea5d04-9af6-4b38-af5c-303756c34e42>
+      ] ;
+    form:hasFieldGroup fieldGroups:5f0ae173-ef30-445a-8411-5eee51fe1910 .
+###########Notulen###########
+
+fieldGroups:2fb408e5-b38a-43fc-8ebe-7c38381312df a form:FieldGroup ;
+    mu:uuid "2fb408e5-b38a-43fc-8ebe-7c38381312df" ;
+    form:hasField
+                      ###Datum-zitting/notulen###
+                      fields:857d670f-9a25-4555-bfe5-ecc48c2ffde3,
+
+                      ###Welk-beslissingsorgaan-nam-het-besluit? (Version for notulen) ###
+                      fields:e24d533f-3e63-4b36-a6af-21c65357e258,
+
+                      ###Links-naar-documenten###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,
+
+                      ###Bestanden###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95a,
+
+                      ###Type RemoteDataObject or FileDataObject###
+                      fields:355fe001-cdca-48cc-8a6e-88b3aab09874,
+
+                      ### RemoteDataObject/url ###
+                      fields:d0052f0d-90bc-4543-a6b0-e90a1c1117db.
+
+fields:0827fafe-ad19-49e1-8b2e-105d2c08a54a form:hasConditionalFieldGroup fields:d441cb26-ea24-4ff7-b5fb-868e36e7d468.
+
+fields:d441cb26-ea24-4ff7-b5fb-868e36e7d468 a form:ConditionalFieldGroup ;
+    mu:uuid "d441cb26-ea24-4ff7-b5fb-868e36e7d468";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitDocumentType/8e791b27-7600-4577-b24e-c7c29e0eb773>
+      ] ;
+    form:hasFieldGroup fieldGroups:2fb408e5-b38a-43fc-8ebe-7c38381312df .
+
+
+###########Oprichting-IGS###########
+
+fieldGroups:ba1888ea-8741-4a4c-911b-74e2335a1680 a form:FieldGroup ;
+    mu:uuid "ba1888ea-8741-4a4c-911b-74e2335a1680" ; 
+    form:hasField 
+                      ###Ondernemingsnummer-betreffend-bedrijf/bestuur###
+                      fields:6ffb0ed7-769a-41e4-b5a9-f6fb0287b235,
+
+                      ###Naam-betreffend-bedrijf/bestuur###
+                      fields:78bfbd91-0778-4573-a52d-4c53b3c512eb,
+
+                      ###Datum-zitting/besluit###
+                      fields:3dd6ed93-40f7-4d70-a6cb-f4de53dc8bfb,
+
+                      ###Datum-zitting/besluit###
+                      fields:3dd6ed93-40f7-4d70-a6cb-f4de53dc8bfb,
+
+                      ###Datum-van-publicatie-op-webtoepassing###
+                      fields:49dbe1be-877a-4890-8465-1510ff18ce18,
+
+                      ###Ondernemingsnummer-betreffend-bedrijf/bestuur###
+                      fields:6ffb0ed7-769a-41e4-b5a9-f6fb0287b235,
+
+                      ###Naam-betreffend-bedrijf/bestuur###
+                      fields:78bfbd91-0778-4573-a52d-4c53b3c512eb,
+
+                      ###Welk-beslissingsorgaan-nam-het-besluit?###
+                      fields:4c7820f0-4011-4ab4-a16a-e128800e11bc,
+
+                      ###Links-naar-documenten###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,
+
+                      ###Bestanden###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95a,
+
+                      ###Type RemoteDataObject or FileDataObject###
+                      fields:355fe001-cdca-48cc-8a6e-88b3aab09874,
+
+                      ### RemoteDataObject/url ###
+                      fields:d0052f0d-90bc-4543-a6b0-e90a1c1117db.
+                      
+fields:0827fafe-ad19-49e1-8b2e-105d2c08a54a form:hasConditionalFieldGroup fields:0269fc98-4ba8-476a-b0d5-817f5f6928aa.
+
+fields:0269fc98-4ba8-476a-b0d5-817f5f6928aa a form:ConditionalFieldGroup ;
+    mu:uuid "0269fc98-4ba8-476a-b0d5-817f5f6928aa";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/1105564e-30c7-4371-a864-6b7329cdae6f>
+      ] ;
+    form:hasFieldGroup fieldGroups:ba1888ea-8741-4a4c-911b-74e2335a1680 .
+
+
+
+###########Oprichting-autonoom-bedrijf###########
+
+fieldGroups:dc8585b7-891d-465f-b2b5-aea3f5323b48 a form:FieldGroup ;
+    mu:uuid "dc8585b7-891d-465f-b2b5-aea3f5323b48" ; 
+    form:hasField 
+                      ###Dossieromschrijving###
+                      fields:bd6ee5ac-22d6-4279-bcba-3ed279021aac,
+
+                      ###Ondernemingsnummer-betreffend-bedrijf/bestuur###
+                      fields:6ffb0ed7-769a-41e4-b5a9-f6fb0287b235,
+
+                      ###Naam-betreffend-bedrijf/bestuur###
+                      fields:78bfbd91-0778-4573-a52d-4c53b3c512eb,
+
+                      ###Datum-zitting/besluit###
+                      fields:3dd6ed93-40f7-4d70-a6cb-f4de53dc8bfb,
+
+                      ###Datum-zitting/besluit###
+                      fields:3dd6ed93-40f7-4d70-a6cb-f4de53dc8bfb,
+
+                      ###Datum-van-publicatie-op-webtoepassing###
+                      fields:49dbe1be-877a-4890-8465-1510ff18ce18,
+
+                      ###Dossieromschrijving###
+                      fields:bd6ee5ac-22d6-4279-bcba-3ed279021aac,
+
+                      ###Ondernemingsnummer-betreffend-bedrijf/bestuur###
+                      fields:6ffb0ed7-769a-41e4-b5a9-f6fb0287b235,
+
+                      ###Naam-betreffend-bedrijf/bestuur###
+                      fields:78bfbd91-0778-4573-a52d-4c53b3c512eb,
+
+                      ###Welk-beslissingsorgaan-nam-het-besluit?###
+                      fields:4c7820f0-4011-4ab4-a16a-e128800e11bc,
+
+                      ###Links-naar-documenten###
+                      fields:1e0f541f-61e9-43a7-bc5f-612eb44f52bb,
+
+                      ###Bestanden###
+                      fields:c7c5a589-0785-4032-a4bd-ee589add3c39,
+
+                      ###Type RemoteDataObject or FileDataObject###
+                      fields:355fe001-cdca-48cc-8a6e-88b3aab09874,
+
+                      ### RemoteDataObject/url ###
+                      fields:d0052f0d-90bc-4543-a6b0-e90a1c1117db.
+
+fields:0827fafe-ad19-49e1-8b2e-105d2c08a54a form:hasConditionalFieldGroup fields:f719b1da-c8c5-4a08-bc74-89c63de96961.
+
+fields:f719b1da-c8c5-4a08-bc74-89c63de96961 a form:ConditionalFieldGroup ;
+    mu:uuid "f719b1da-c8c5-4a08-bc74-89c63de96961";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/bd0b0c42-ba5e-4acc-b644-95f6aad904c7>
+      ] ;
+    form:hasFieldGroup fieldGroups:dc8585b7-891d-465f-b2b5-aea3f5323b48 .
+
+
+
+###########Oprichting-districtsbestuur###########
+
+fieldGroups:6749f691-29b3-459c-8054-f78a3d816db2 a form:FieldGroup ;
+    mu:uuid "6749f691-29b3-459c-8054-f78a3d816db2" ; 
+    form:hasField 
+                      ###Opmerking###
+                      fields:0cdfe85f-ec65-498f-bd26-0ec611967de0,
+
+                      ###Datum-zitting/besluit###
+                      fields:3dd6ed93-40f7-4d70-a6cb-f4de53dc8bfb,
+
+                      ###Datum-zitting/besluit###
+                      fields:3dd6ed93-40f7-4d70-a6cb-f4de53dc8bfb,
+
+                      ###Ondernemingsnummer-betreffend-bedrijf/bestuur###
+                      fields:6ffb0ed7-769a-41e4-b5a9-f6fb0287b235,
+
+                      ###Naam-betreffend-bedrijf/bestuur###
+                      fields:78bfbd91-0778-4573-a52d-4c53b3c512eb,
+
+                      ###Opmerking###
+                      fields:0cdfe85f-ec65-498f-bd26-0ec611967de0,
+
+                      ###Datum-van-publicatie-op-webtoepassing###
+                      fields:49dbe1be-877a-4890-8465-1510ff18ce18,
+
+                      ###Ondernemingsnummer-betreffend-bedrijf/bestuur###
+                      fields:6ffb0ed7-769a-41e4-b5a9-f6fb0287b235,
+
+                      ###Naam-betreffend-bedrijf/bestuur###
+                      fields:78bfbd91-0778-4573-a52d-4c53b3c512eb,
+
+                      ###Welk-beslissingsorgaan-nam-het-besluit?###
+                      fields:4c7820f0-4011-4ab4-a16a-e128800e11bc,
+
+                      ###Links-naar-documenten###
+                      fields:1e0f541f-61e9-43a7-bc5f-612eb44f52bb,
+
+                      ###Bestanden###
+                      fields:c7c5a589-0785-4032-a4bd-ee589add3c39,
+
+                      ###Type RemoteDataObject or FileDataObject###
+                      fields:355fe001-cdca-48cc-8a6e-88b3aab09874,
+
+                      ### RemoteDataObject/url ###
+                      fields:d0052f0d-90bc-4543-a6b0-e90a1c1117db.
+                      
+fields:0827fafe-ad19-49e1-8b2e-105d2c08a54a form:hasConditionalFieldGroup fields:6a56792c-5a47-473d-9db3-3362f96a1cda.
+
+fields:6a56792c-5a47-473d-9db3-3362f96a1cda a form:ConditionalFieldGroup ;
+    mu:uuid "6a56792c-5a47-473d-9db3-3362f96a1cda";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/380674ee-0894-4c41-bcc1-9deaeb9d464c>
+      ] ;
+    form:hasFieldGroup fieldGroups:6749f691-29b3-459c-8054-f78a3d816db2 .
+
+
+
+###########Oprichting-ocmw-vereniging###########
+
+fieldGroups:831b8af6-4ce7-4b5c-8261-97a3a9309239 a form:FieldGroup ;
+    mu:uuid "831b8af6-4ce7-4b5c-8261-97a3a9309239" ; 
+    form:hasField 
+                      ###Ondernemingsnummer-betreffend-bedrijf/bestuur###
+                      fields:6ffb0ed7-769a-41e4-b5a9-f6fb0287b235,
+
+                      ###Naam-betreffend-bedrijf/bestuur###
+                      fields:78bfbd91-0778-4573-a52d-4c53b3c512eb,
+
+                      ###Datum-zitting/besluit###
+                      fields:3dd6ed93-40f7-4d70-a6cb-f4de53dc8bfb,
+
+                      ###Datum-zitting/besluit###
+                      fields:3dd6ed93-40f7-4d70-a6cb-f4de53dc8bfb,
+
+                      ###Datum-van-publicatie-op-webtoepassing###
+                      fields:49dbe1be-877a-4890-8465-1510ff18ce18,
+
+                      ###Ondernemingsnummer-betreffend-bedrijf/bestuur###
+                      fields:6ffb0ed7-769a-41e4-b5a9-f6fb0287b235,
+
+                      ###Naam-betreffend-bedrijf/bestuur###
+                      fields:78bfbd91-0778-4573-a52d-4c53b3c512eb,
+
+                      ###Welk-beslissingsorgaan-nam-het-besluit?###
+                      fields:4c7820f0-4011-4ab4-a16a-e128800e11bc,
+
+                      ###Links-naar-documenten###
+                      fields:1e0f541f-61e9-43a7-bc5f-612eb44f52bb,
+
+                      ###Bestanden###
+                      fields:c7c5a589-0785-4032-a4bd-ee589add3c39,
+
+                      ###Type RemoteDataObject or FileDataObject###
+                      fields:355fe001-cdca-48cc-8a6e-88b3aab09874,
+
+                      ### RemoteDataObject/url ###
+                      fields:d0052f0d-90bc-4543-a6b0-e90a1c1117db.
+                      
+fields:0827fafe-ad19-49e1-8b2e-105d2c08a54a form:hasConditionalFieldGroup fields:fbc56ed1-bb0d-44fe-9dee-75d64f722ada.
+
+fields:fbc56ed1-bb0d-44fe-9dee-75d64f722ada a form:ConditionalFieldGroup ;
+    mu:uuid "fbc56ed1-bb0d-44fe-9dee-75d64f722ada";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/b69c9f18-967c-4feb-90a8-8eea3c8ce46b>
+      ] ;
+    form:hasFieldGroup fieldGroups:831b8af6-4ce7-4b5c-8261-97a3a9309239 .
+
+
+
+###########Oprichting-of-deelname-EVA###########
+
+fieldGroups:479990ad-12a3-43b1-a3cf-3d9897e59357 a form:FieldGroup ;
+    mu:uuid "479990ad-12a3-43b1-a3cf-3d9897e59357" ; 
+    form:hasField 
+                      ###Datum-zitting/besluit###
+                      fields:3dd6ed93-40f7-4d70-a6cb-f4de53dc8bfb,
+
+                      ###Welk-beslissingsorgaan-nam-het-besluit?###
+                      fields:bffbea8d-e55b-4e3d-86e8-ba7aaee7863d,
+
+                      ###Datum-zitting/besluit###
+                      fields:3dd6ed93-40f7-4d70-a6cb-f4de53dc8bfb,
+
+                      ###Ondernemingsnummer-betreffend-bedrijf/bestuur###
+                      fields:6ffb0ed7-769a-41e4-b5a9-f6fb0287b235,
+
+                      ###Naam-betreffend-bedrijf/bestuur###
+                      fields:78bfbd91-0778-4573-a52d-4c53b3c512eb,
+
+                      ###Datum-van-publicatie-op-webtoepassing###
+                      fields:49dbe1be-877a-4890-8465-1510ff18ce18,
+
+                      ###Ondernemingsnummer-betreffend-bedrijf/bestuur###
+                      fields:6ffb0ed7-769a-41e4-b5a9-f6fb0287b235,
+
+                      ###Naam-betreffend-bedrijf/bestuur###
+                      fields:78bfbd91-0778-4573-a52d-4c53b3c512eb,
+
+                      ###Links-naar-documenten###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,
+
+                      ###Bestanden###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95a,
+
+                      ###Type RemoteDataObject or FileDataObject###
+                      fields:355fe001-cdca-48cc-8a6e-88b3aab09874,
+
+                      ### RemoteDataObject/url ###
+                      fields:d0052f0d-90bc-4543-a6b0-e90a1c1117db.
+                      
+fields:0827fafe-ad19-49e1-8b2e-105d2c08a54a form:hasConditionalFieldGroup fields:b13143f6-f547-4aa2-9ed0-485a0dc7a354.
+
+fields:b13143f6-f547-4aa2-9ed0-485a0dc7a354 a form:ConditionalFieldGroup ;
+    mu:uuid "b13143f6-f547-4aa2-9ed0-485a0dc7a354";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/f8c070bd-96e4-43a1-8c6e-532bcd771251>
+      ] ;
+    form:hasFieldGroup fieldGroups:479990ad-12a3-43b1-a3cf-3d9897e59357 .
+
+###########Overruling visum###########
+
+fieldGroups:58b112ad-98af-450f-8c67-01416cc2cebb a form:FieldGroup ;
+    mu:uuid "58b112ad-98af-450f-8c67-01416cc2cebb" ;
+    form:hasField
+                      ###Datum-zitting/besluit###
+                      fields:3dd6ed93-40f7-4d70-a6cb-f4de53dc8bfb,
+
+                      ###Welk-beslissingsorgaan-nam-het-besluit?###
+                      fields:bffbea8d-e55b-4e3d-86e8-ba7aaee7863d,
+
+                      ###Links-naar-documenten###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,
+
+                      ###Bestanden###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95a,
+
+                      ###Type RemoteDataObject or FileDataObject###
+                      fields:355fe001-cdca-48cc-8a6e-88b3aab09874,
+
+                      ### RemoteDataObject/url ###
+                      fields:d0052f0d-90bc-4543-a6b0-e90a1c1117db.
+
+fields:0827fafe-ad19-49e1-8b2e-105d2c08a54a form:hasConditionalFieldGroup fields:8e149ca6-75e6-4b73-9744-31eae25ba10d.
+
+fields:8e149ca6-75e6-4b73-9744-31eae25ba10d a form:ConditionalFieldGroup ;
+    mu:uuid "8e149ca6-75e6-4b73-9744-31eae25ba10d";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/ceaa6eec-504d-496f-afbc-cfac6aafa154>
+      ] ;
+    form:hasFieldGroup fieldGroups:58b112ad-98af-450f-8c67-01416cc2cebb .
+########### Overzicht vergoedingen en presentiegelden ###########
+
+# Conditionally add the form fields to the "type dossier" field
+fields:0827fafe-ad19-49e1-8b2e-105d2c08a54a form:hasConditionalFieldGroup fields:26b8392b-4097-4e99-8fec-832d063d316b.
+
+# Only add the fields if the user selected the "Overzicht vergoedingen en presentiegelden" option
+fields:26b8392b-4097-4e99-8fec-832d063d316b a form:ConditionalFieldGroup ;
+    mu:uuid "26b8392b-4097-4e99-8fec-832d063d316b";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitDocumentType/365d561c-57c7-4523-af04-6e3c91426c56>
+      ] ;
+    form:hasFieldGroup fieldGroups:8a07bf7d-c99f-47fa-9bcf-a4b7d221ac28 .
+
+fieldGroups:8a07bf7d-c99f-47fa-9bcf-a4b7d221ac28 a form:FieldGroup ;
+    mu:uuid "8a07bf7d-c99f-47fa-9bcf-a4b7d221ac28" ;
+
+    form:hasField
+      ### Links-naar-documenten ###
+      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b ,
+
+      ### File uploader with custom help text
+      fields:1d8f3fa0-a908-494c-8cd3-48035f581936,
+
+      ###Type RemoteDataObject or FileDataObject###
+      fields:355fe001-cdca-48cc-8a6e-88b3aab09874,
+
+      ### RemoteDataObject/url ###
+      fields:d0052f0d-90bc-4543-a6b0-e90a1c1117db.
+
+############################################################################################
+# Custom form fields for the "Overzicht vergoedingen en presentiegelden" form
+############################################################################################
+
+## File upload with custom help text
+fields:1d8f3fa0-a908-494c-8cd3-48035f581936 a form:Field ;
+    mu:uuid "1d8f3fa0-a908-494c-8cd3-48035f581936" ;
+    sh:name "Bestanden" ;
+    sh:order 10001 ;
+    sh:path dct:hasPart;
+    form:validations
+     [ a  form:RequiredConstraint ;
+          form:grouping form:Bag ;
+          sh:path dct:hasPart;
+          sh:resultMessage "Gelieve minstens één URL of bestand op te geven."@nl # TODO: later custom validator
+     ];
+    form:displayType displayTypes:files; # consider this v1.0
+    form:help """Hier dient u de exceltabel in te dienen met een per mandataris geïndividualiseerd overzicht van de vergoedingen en de presentiegelden zoals bepaald in artikel 448, vierde lid DLB.""";
+    sh:group fields:aDynamicPropertyGroup .
+
+
+###########Advies budget(wijziging)-RO###########
+
+fieldGroups:abb02ef6-581d-4876-aa45-acd1fbc4f49b a form:FieldGroup ;
+    mu:uuid "abb02ef6-581d-4876-aa45-acd1fbc4f49b" ; 
+    form:hasField 
+
+                      ###Eredienst selector###
+                      fields:eb089ca1-2c5b-42a4-a781-f009c46ac583,
+
+                      ###Datum-zitting/besluit###
+                      fields:3dd6ed93-40f7-4d70-a6cb-f4de53dc8bfb,
+
+                      ###Datum-zitting/besluit###
+                      fields:3dd6ed93-40f7-4d70-a6cb-f4de53dc8bfb,
+
+                      ###Links-naar-documenten###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,
+
+                      ###Bestanden###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95a,
+
+                      ###Type RemoteDataObject or FileDataObject###
+                      fields:355fe001-cdca-48cc-8a6e-88b3aab09874,
+
+                      ### RemoteDataObject/url ###
+                      fields:d0052f0d-90bc-4543-a6b0-e90a1c1117db.
+
+fields:0827fafe-ad19-49e1-8b2e-105d2c08a54a form:hasConditionalFieldGroup fields:af9a1822-dc7a-45f4-b126-e57ed0d022d0.
+
+fields:af9a1822-dc7a-45f4-b126-e57ed0d022d0 a form:ConditionalFieldGroup ;
+    mu:uuid "af9a1822-dc7a-45f4-b126-e57ed0d022d0";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/2b12630f-8c4e-40a4-8a61-a0c45621a1e6>
+      ] ;
+    form:hasFieldGroup fieldGroups:abb02ef6-581d-4876-aa45-acd1fbc4f49b .
+
+###########Advies meerjarenplan(wijziging)-RO###########
+
+fieldGroups:253be7ce-f723-4e82-8b24-3e55e0602aaa a form:FieldGroup ;
+    mu:uuid "253be7ce-f723-4e82-8b24-3e55e0602aaa" ; 
+    form:hasField 
+
+                      ###Eredienst selector###
+                      fields:eb089ca1-2c5b-42a4-a781-f009c46ac583,
+
+                      ###Datum-zitting/besluit###
+                      fields:3dd6ed93-40f7-4d70-a6cb-f4de53dc8bfb,
+
+                      ###Datum-zitting/besluit###
+                      fields:3dd6ed93-40f7-4d70-a6cb-f4de53dc8bfb,
+
+                      ###Links-naar-documenten###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,
+
+                      ###Bestanden###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95a,
+
+                      ###Type RemoteDataObject or FileDataObject###
+                      fields:355fe001-cdca-48cc-8a6e-88b3aab09874,
+
+                      ### RemoteDataObject/url ###
+                      fields:d0052f0d-90bc-4543-a6b0-e90a1c1117db.
+
+fields:0827fafe-ad19-49e1-8b2e-105d2c08a54a form:hasConditionalFieldGroup fields:4c88c8af-4a47-444a-9280-7b60b54cfcb2 .
+
+fields:4c88c8af-4a47-444a-9280-7b60b54cfcb2 a form:ConditionalFieldGroup ;
+    mu:uuid "4c88c8af-4a47-444a-9280-7b60b54cfcb2";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/0fc2c27d-a03c-4e3f-9db1-f10f026f76f8>
+      ] ;
+    form:hasFieldGroup fieldGroups:253be7ce-f723-4e82-8b24-3e55e0602aaa .
+
+###########Erkenning - Reguliere procedure###########
+
+fieldGroups:5e65edf0-3443-4525-b4df-02009074d84f a form:FieldGroup ;
+    mu:uuid "5e65edf0-3443-4525-b4df-02009074d84f" ; 
+    form:hasField 
+
+                      ###Label met link naar webpagina###
+                      fields:9724f76e-6b1d-480d-a868-f24b74f236a0,
+
+                      ###Links-naar-documenten###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,
+
+                      ###Bestanden###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95a,
+
+                      ###Type RemoteDataObject or FileDataObject###
+                      fields:355fe001-cdca-48cc-8a6e-88b3aab09874,
+
+                      ### RemoteDataObject/url ###
+                      fields:d0052f0d-90bc-4543-a6b0-e90a1c1117db.
+
+fields:0827fafe-ad19-49e1-8b2e-105d2c08a54a form:hasConditionalFieldGroup fields:c90d9bae-4fc5-4db6-898d-49d5ed56871c .
+
+fields:c90d9bae-4fc5-4db6-898d-49d5ed56871c a form:ConditionalFieldGroup ;
+    mu:uuid "c90d9bae-4fc5-4db6-898d-49d5ed56871c";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitDocumentType/651525f8-8650-4ce8-8eea-f19b94d50b73>
+      ] ;
+    form:hasFieldGroup fieldGroups:5e65edf0-3443-4525-b4df-02009074d84f .
+
+
+
+###########Naamswijziging###########
+
+fieldGroups:d390d46b-ccf0-4da5-ba54-7ac372a32045 a form:FieldGroup ;
+    mu:uuid "d390d46b-ccf0-4da5-ba54-7ac372a32045" ; 
+    form:hasField 
+
+                      ###Label met link naar webpagina###
+                      fields:9724f76e-6b1d-480d-a868-f24b74f236a0,
+
+                      ###Links-naar-documenten###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,
+
+                      ###Bestanden###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95a,
+
+                      ###Type RemoteDataObject or FileDataObject###
+                      fields:355fe001-cdca-48cc-8a6e-88b3aab09874,
+
+                      ### RemoteDataObject/url ###
+                      fields:d0052f0d-90bc-4543-a6b0-e90a1c1117db.
+
+fields:0827fafe-ad19-49e1-8b2e-105d2c08a54a form:hasConditionalFieldGroup fields:33cf1efd-a8c9-4035-a205-2df390b9c0b3.
+
+fields:33cf1efd-a8c9-4035-a205-2df390b9c0b3 a form:ConditionalFieldGroup ;
+    mu:uuid "33cf1efd-a8c9-4035-a205-2df390b9c0b3";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitDocumentType/d611364b-007b-49a7-b2bf-b8f4e5568777>
+      ] ;
+    form:hasFieldGroup fieldGroups:d390d46b-ccf0-4da5-ba54-7ac372a32045 .
+
+
+
+###########Opheffing van annexe kerken en kapelanijen###########
+
+fieldGroups:cb043882-7721-4fde-839a-ee3a9e11bf0b a form:FieldGroup ;
+    mu:uuid "cb043882-7721-4fde-839a-ee3a9e11bf0b" ; 
+    form:hasField 
+
+                      ###Label met link naar webpagina###
+                      fields:9724f76e-6b1d-480d-a868-f24b74f236a0,
+
+                      ###Links-naar-documenten###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,
+
+                      ###Bestanden###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95a,
+
+                      ###Type RemoteDataObject or FileDataObject###
+                      fields:355fe001-cdca-48cc-8a6e-88b3aab09874,
+
+                      ### RemoteDataObject/url ###
+                      fields:d0052f0d-90bc-4543-a6b0-e90a1c1117db.
+
+fields:0827fafe-ad19-49e1-8b2e-105d2c08a54a form:hasConditionalFieldGroup fields:763a7a43-095a-44e8-bb95-44fb01e15bf0.
+
+fields:763a7a43-095a-44e8-bb95-44fb01e15bf0 a form:ConditionalFieldGroup ;
+    mu:uuid "763a7a43-095a-44e8-bb95-44fb01e15bf0";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitDocumentType/6d1a3aea-6773-4e10-924d-38be596c5e2e>
+      ] ;
+    form:hasFieldGroup fieldGroups:cb043882-7721-4fde-839a-ee3a9e11bf0b .
+
+
+
+###########Samenvoeging###########
+
+fieldGroups:c14040dc-6a97-4909-93cf-fe15e4099a01 a form:FieldGroup ;
+    mu:uuid "c14040dc-6a97-4909-93cf-fe15e4099a01" ; 
+    form:hasField 
+
+                      ###Label met link naar webpagina###
+                      fields:9724f76e-6b1d-480d-a868-f24b74f236a0,
+
+                      ###Links-naar-documenten###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,
+
+                      ###Bestanden###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95a,
+
+                      ###Type RemoteDataObject or FileDataObject###
+                      fields:355fe001-cdca-48cc-8a6e-88b3aab09874,
+
+                      ### RemoteDataObject/url ###
+                      fields:d0052f0d-90bc-4543-a6b0-e90a1c1117db.
+
+fields:0827fafe-ad19-49e1-8b2e-105d2c08a54a form:hasConditionalFieldGroup fields:24c1dc09-0e31-4e73-a89d-5b7bc4e2bcd9 .
+
+fields:24c1dc09-0e31-4e73-a89d-5b7bc4e2bcd9 a form:ConditionalFieldGroup ;
+    mu:uuid "24c1dc09-0e31-4e73-a89d-5b7bc4e2bcd9";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitDocumentType/14793940-5b9c-4172-b108-c73665ad9d6a>
+      ] ;
+    form:hasFieldGroup fieldGroups:c14040dc-6a97-4909-93cf-fe15e4099a01 .
+
+
+
+###########Wijziging gebiedsomschrijving###########
+
+fieldGroups:690b5b55-2bef-459f-85e0-9a417c71efa9 a form:FieldGroup ;
+    mu:uuid "690b5b55-2bef-459f-85e0-9a417c71efa9" ; 
+    form:hasField 
+
+                      ###Label met link naar webpagina###
+                      fields:9724f76e-6b1d-480d-a868-f24b74f236a0,
+
+                      ###Links-naar-documenten###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,
+
+                      ###Bestanden###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95a,
+
+                      ###Type RemoteDataObject or FileDataObject###
+                      fields:355fe001-cdca-48cc-8a6e-88b3aab09874,
+
+                      ### RemoteDataObject/url ###
+                      fields:d0052f0d-90bc-4543-a6b0-e90a1c1117db.
+
+fields:0827fafe-ad19-49e1-8b2e-105d2c08a54a form:hasConditionalFieldGroup fields:2843f96c-b514-4c7c-a9b9-e8c463812750.
+
+fields:2843f96c-b514-4c7c-a9b9-e8c463812750 a form:ConditionalFieldGroup ;
+    mu:uuid "2843f96c-b514-4c7c-a9b9-e8c463812750";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitDocumentType/95a6c5a1-05af-4d48-b2ef-5ebb1e58783b>
+      ] ;
+    form:hasFieldGroup fieldGroups:690b5b55-2bef-459f-85e0-9a417c71efa9 .
+
+fieldGroups:97b8287e-0a95-4f08-a60f-8f0a468ad7d2 a form:FieldGroup ;
+    mu:uuid "97b8287e-0a95-4f08-a60f-8f0a468ad7d2" ;
+    form:hasField
+
+                      ###Links-naar-documenten###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,
+
+                      ###Bestanden###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95a.
+
+# this field is the custom bestuursorgaan selector
+fields:4c7820f0-4011-4ab4-a16a-e128800e11bc form:hasConditionalFieldGroup fields:8112d820-9f26-4157-82fe-98eb1773e11f.
+
+fields:8112d820-9f26-4157-82fe-98eb1773e11f a form:ConditionalFieldGroup ;
+    mu:uuid "8112d820-9f26-4157-82fe-98eb1773e11f";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/fb21d14b-734b-48f4-bd4e-888163fd08e8>
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuursorgaanClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> # Algemene vergadering
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:bestuurt besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuurseenheidClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/36a82ba0-7ff1-4697-a9dd-2e94df73b721> # Autonoom gemeentebedrijf
+      ] ;
+    form:hasFieldGroup fieldGroups:97b8287e-0a95-4f08-a60f-8f0a468ad7d2 .fieldGroups:97b8287e-0a95-4f08-a60f-8f0a468ad7d2 a form:FieldGroup ;
+    mu:uuid "97b8287e-0a95-4f08-a60f-8f0a468ad7d2" ;
+    form:hasField
+
+                      ###Links-naar-documenten###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,
+
+                      ###Bestanden###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95a.
+
+# this field is the custom bestuursorgaan selector
+fields:4c7820f0-4011-4ab4-a16a-e128800e11bc form:hasConditionalFieldGroup fields:dc1b5303-c99e-432b-94ad-70d43e94ecc4.
+
+fields:dc1b5303-c99e-432b-94ad-70d43e94ecc4 a form:ConditionalFieldGroup ;
+    mu:uuid "dc1b5303-c99e-432b-94ad-70d43e94ecc4";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/fb21d14b-734b-48f4-bd4e-888163fd08e8>
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuursorgaanClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> # Algemene vergadering
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:bestuurt besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuurseenheidClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/80310756-ce0a-4a1b-9b8e-7c01b6cc7a2d> # Autonoom provinciebedrijf
+      ] ;
+    form:hasFieldGroup fieldGroups:97b8287e-0a95-4f08-a60f-8f0a468ad7d2 .
+fieldGroups:8de31aba-07e0-4015-9189-dc6201aeabc2 a form:FieldGroup ;
+    mu:uuid "8de31aba-07e0-4015-9189-dc6201aeabc2" ;
+    form:hasField
+
+                      ###Links-naar-documenten###
+                      fields:1e0f541f-61e9-43a7-bc5f-612eb44f52bb,
+
+                      ###Bestanden###
+                      fields:c7c5a589-0785-4032-a4bd-ee589add3c39.
+
+# this field is the custom bestuursorgaan selector
+fields:4c7820f0-4011-4ab4-a16a-e128800e11bc form:hasConditionalFieldGroup fields:4b7cee25-d206-40f6-8c7e-1677db355551.
+
+fields:4b7cee25-d206-40f6-8c7e-1677db355551 a form:ConditionalFieldGroup ;
+    mu:uuid "4b7cee25-d206-40f6-8c7e-1677db355551";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/fb21d14b-734b-48f4-bd4e-888163fd08e8>
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuursorgaanClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> # Algemene vergadering
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:bestuurt besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuurseenheidClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/d01bb1f6-2439-4e33-9c25-1fc295de2e71> # Dienstverlenende vereniging
+      ] ;
+    form:hasFieldGroup fieldGroups:8de31aba-07e0-4015-9189-dc6201aeabc2 .fieldGroups:5d66d345-0d17-4899-8a4a-ff4083c82f45 a form:FieldGroup ;
+    mu:uuid "5d66d345-0d17-4899-8a4a-ff4083c82f45" ;
+    form:hasField
+
+                      ###Links-naar-documenten###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,
+
+                      ###Bestanden###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95a.
+
+# this field is the custom bestuursorgaan selector
+fields:4c7820f0-4011-4ab4-a16a-e128800e11bc form:hasConditionalFieldGroup fields:9f875fc1-034b-4ebe-9e30-9087238ff4a2.
+
+fields:9f875fc1-034b-4ebe-9e30-9087238ff4a2 a form:ConditionalFieldGroup ;
+    mu:uuid "9f875fc1-034b-4ebe-9e30-9087238ff4a2";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/fb21d14b-734b-48f4-bd4e-888163fd08e8>
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuursorgaanClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> # Algemene vergadering
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:bestuurt besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuurseenheidClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/cc4e2d67-603b-4784-9b61-e50bac1ec089> # OCMW vereniging
+      ] ;
+    form:hasFieldGroup fieldGroups:5d66d345-0d17-4899-8a4a-ff4083c82f45 .fieldGroups:5d79af21-9efc-4ef4-87a0-34787de86e11 a form:FieldGroup ;
+    mu:uuid "5d79af21-9efc-4ef4-87a0-34787de86e11" ;
+    form:hasField
+
+                      ###Links-naar-documenten###
+                      fields:1e0f541f-61e9-43a7-bc5f-612eb44f52bb,
+
+                      ###Bestanden###
+                      fields:c7c5a589-0785-4032-a4bd-ee589add3c39.
+
+# this field is the custom bestuursorgaan selector
+fields:4c7820f0-4011-4ab4-a16a-e128800e11bc form:hasConditionalFieldGroup fields:17832f91-07f3-4ebc-8659-5c9a70d3bb1b.
+
+fields:17832f91-07f3-4ebc-8659-5c9a70d3bb1b a form:ConditionalFieldGroup ;
+    mu:uuid "17832f91-07f3-4ebc-8659-5c9a70d3bb1b";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/fb21d14b-734b-48f4-bd4e-888163fd08e8>
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuursorgaanClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> # Algemene vergadering
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:bestuurt besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuurseenheidClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/cd93f147-3ece-4308-acab-5c5ada3ec63d> # Opdrachthoudende vereniging
+      ] ;
+    form:hasFieldGroup fieldGroups:5d79af21-9efc-4ef4-87a0-34787de86e11 .fieldGroups:cc3c56c7-1eec-4541-a965-d87241edb265 a form:FieldGroup ;
+    mu:uuid "cc3c56c7-1eec-4541-a965-d87241edb265" ;
+    form:hasField
+
+                      ###Links-naar-documenten###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,
+
+                      ###Bestanden###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95a.
+
+# this field is the custom bestuursorgaan selector
+fields:4c7820f0-4011-4ab4-a16a-e128800e11bc form:hasConditionalFieldGroup fields:d043d435-413d-40d8-b11e-8e6c4788c907.
+
+fields:d043d435-413d-40d8-b11e-8e6c4788c907 a form:ConditionalFieldGroup ;
+    mu:uuid "d043d435-413d-40d8-b11e-8e6c4788c907";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/fb21d14b-734b-48f4-bd4e-888163fd08e8>
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuursorgaanClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/0dbc70ec-6be9-4997-b8e1-11b6c0542382> # Bevoegd beslissingsorgaan
+      ] ;
+    form:hasFieldGroup fieldGroups:cc3c56c7-1eec-4541-a965-d87241edb265 .fieldGroups:a864e22b-6b3f-4993-b4e0-92af6c37597c a form:FieldGroup ;
+    mu:uuid "a864e22b-6b3f-4993-b4e0-92af6c37597c" ;
+    form:hasField
+
+                      ###Links-naar-documenten###
+                      fields:1e0f541f-61e9-43a7-bc5f-612eb44f52bb,
+
+                      ###Bestanden###
+                      fields:c7c5a589-0785-4032-a4bd-ee589add3c39.
+
+# this field is the custom bestuursorgaan selector
+fields:4c7820f0-4011-4ab4-a16a-e128800e11bc form:hasConditionalFieldGroup fields:6f6b085b-15a4-467a-adc1-701fd26a8f02.
+
+fields:6f6b085b-15a4-467a-adc1-701fd26a8f02 a form:ConditionalFieldGroup ;
+    mu:uuid "6f6b085b-15a4-467a-adc1-701fd26a8f02";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/fb21d14b-734b-48f4-bd4e-888163fd08e8>
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuursorgaanClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000009> # Bijzonder Comité voor de Sociale Dienst
+      ] ;
+    form:hasFieldGroup fieldGroups:a864e22b-6b3f-4993-b4e0-92af6c37597c .fieldGroups:c824e597-6bd5-42b3-b636-90f1921de923 a form:FieldGroup ;
+    mu:uuid "c824e597-6bd5-42b3-b636-90f1921de923" ;
+    form:hasField
+
+                      ###Links-naar-documenten###
+                      fields:1e0f541f-61e9-43a7-bc5f-612eb44f52bb,
+
+                      ###Bestanden###
+                      fields:c7c5a589-0785-4032-a4bd-ee589add3c39.
+
+# this field is the custom bestuursorgaan selector
+fields:4c7820f0-4011-4ab4-a16a-e128800e11bc form:hasConditionalFieldGroup fields:3467fac0-fafd-4bce-bd62-11d00e4ad064.
+
+fields:3467fac0-fafd-4bce-bd62-11d00e4ad064 a form:ConditionalFieldGroup ;
+    mu:uuid "3467fac0-fafd-4bce-bd62-11d00e4ad064";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/fb21d14b-734b-48f4-bd4e-888163fd08e8>
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuursorgaanClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/4955bd72cd0e4eb895fdbfab08da0284> # burgemeester
+      ] ;
+    form:hasFieldGroup fieldGroups:c824e597-6bd5-42b3-b636-90f1921de923 .fieldGroups:793bea47-3436-41a4-b922-8fd967e11813 a form:FieldGroup ;
+    mu:uuid "793bea47-3436-41a4-b922-8fd967e11813" ;
+    form:hasField
+
+                      ###Links-naar-documenten###
+                      fields:1e0f541f-61e9-43a7-bc5f-612eb44f52bb,
+
+                      ###Bestanden###
+                      fields:c7c5a589-0785-4032-a4bd-ee589add3c39.
+
+# this field is the custom bestuursorgaan selector
+fields:4c7820f0-4011-4ab4-a16a-e128800e11bc form:hasConditionalFieldGroup fields:913a1db8-230a-4046-b75f-b59be0519f84.
+
+fields:913a1db8-230a-4046-b75f-b59be0519f84 a form:ConditionalFieldGroup ;
+    mu:uuid "913a1db8-230a-4046-b75f-b59be0519f84";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/fb21d14b-734b-48f4-bd4e-888163fd08e8>
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuursorgaanClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000006> # college van schepenen en burgermeester
+      ] ;
+    form:hasFieldGroup fieldGroups:793bea47-3436-41a4-b922-8fd967e11813 .fieldGroups:fd9e7fd5-eb23-483e-949e-329d79f3eef1 a form:FieldGroup ;
+    mu:uuid "fd9e7fd5-eb23-483e-949e-329d79f3eef1" ;
+    form:hasField
+
+                      ###Links-naar-documenten###
+                      fields:1e0f541f-61e9-43a7-bc5f-612eb44f52bb,
+
+                      ###Bestanden###
+                      fields:c7c5a589-0785-4032-a4bd-ee589add3c39.
+
+# this field is the custom bestuursorgaan selector
+fields:4c7820f0-4011-4ab4-a16a-e128800e11bc form:hasConditionalFieldGroup fields:cc4a0e56-bd6b-4325-bdc4-a7afb97c6824.
+
+fields:cc4a0e56-bd6b-4325-bdc4-a7afb97c6824 a form:ConditionalFieldGroup ;
+    mu:uuid "cc4a0e56-bd6b-4325-bdc4-a7afb97c6824";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/fb21d14b-734b-48f4-bd4e-888163fd08e8>
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuursorgaanClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e00000d> # deputatie
+      ] ;
+    form:hasFieldGroup fieldGroups:fd9e7fd5-eb23-483e-949e-329d79f3eef1 .fieldGroups:7a551112-2bc5-4d86-9d74-0df548780afe a form:FieldGroup ;
+    mu:uuid "7a551112-2bc5-4d86-9d74-0df548780afe" ;
+    form:hasField
+
+                      ###Links-naar-documenten###
+                      fields:1e0f541f-61e9-43a7-bc5f-612eb44f52bb,
+
+                      ###Bestanden###
+                      fields:c7c5a589-0785-4032-a4bd-ee589add3c39.
+
+# this field is the custom bestuursorgaan selector
+fields:4c7820f0-4011-4ab4-a16a-e128800e11bc form:hasConditionalFieldGroup fields:f0007086-48b5-4f3b-a7a6-c79a17c97130.
+
+fields:f0007086-48b5-4f3b-a7a6-c79a17c97130 a form:ConditionalFieldGroup ;
+    mu:uuid "f0007086-48b5-4f3b-a7a6-c79a17c97130";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/fb21d14b-734b-48f4-bd4e-888163fd08e8>
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuursorgaanClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5733254e-73ff-4844-8d43-7afb7ec726e8> # directiecomité
+      ] ;
+    form:hasFieldGroup fieldGroups:7a551112-2bc5-4d86-9d74-0df548780afe .fieldGroups:c487ca14-f048-4cad-ab0d-999ad5f7912f a form:FieldGroup ;
+    mu:uuid "c487ca14-f048-4cad-ab0d-999ad5f7912f" ;
+    form:hasField
+
+                      ###Links-naar-documenten###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,
+
+                      ###Bestanden###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95a.
+
+# this field is the custom bestuursorgaan selector
+fields:4c7820f0-4011-4ab4-a16a-e128800e11bc form:hasConditionalFieldGroup fields:3abffb79-1ac5-4825-879b-91faf17d69be.
+
+fields:3abffb79-1ac5-4825-879b-91faf17d69be a form:ConditionalFieldGroup ;
+    mu:uuid "3abffb79-1ac5-4825-879b-91faf17d69be";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/fb21d14b-734b-48f4-bd4e-888163fd08e8>
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuursorgaanClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/9314533e-891f-4d84-a492-0338af104065> # Districtsburgemeester
+      ] ;
+    form:hasFieldGroup fieldGroups:c487ca14-f048-4cad-ab0d-999ad5f7912f .fieldGroups:8fe90017-cd9a-401f-8c08-2491cf162926 a form:FieldGroup ;
+    mu:uuid "8fe90017-cd9a-401f-8c08-2491cf162926" ;
+    form:hasField
+
+                      ###Links-naar-documenten###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,
+
+                      ###Bestanden###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95a.
+
+# this field is the custom bestuursorgaan selector
+fields:4c7820f0-4011-4ab4-a16a-e128800e11bc form:hasConditionalFieldGroup fields:14b79b97-1691-4b1a-aa99-e6fc0ee6f930.
+
+fields:14b79b97-1691-4b1a-aa99-e6fc0ee6f930 a form:ConditionalFieldGroup ;
+    mu:uuid "14b79b97-1691-4b1a-aa99-e6fc0ee6f930";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/fb21d14b-734b-48f4-bd4e-888163fd08e8>
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuursorgaanClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e00000b> # Districtscollege
+      ] ;
+    form:hasFieldGroup fieldGroups:8fe90017-cd9a-401f-8c08-2491cf162926 .fieldGroups:ea030090-ed7d-477d-a94d-ff0797c757ac a form:FieldGroup ;
+    mu:uuid "ea030090-ed7d-477d-a94d-ff0797c757ac" ;
+    form:hasField
+
+                      ###Links-naar-documenten###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,
+
+                      ###Bestanden###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95a.
+
+# this field is the custom bestuursorgaan selector
+fields:4c7820f0-4011-4ab4-a16a-e128800e11bc form:hasConditionalFieldGroup fields:81e12e46-5a19-4911-a9df-cea6ec135ca1.
+
+fields:81e12e46-5a19-4911-a9df-cea6ec135ca1 a form:ConditionalFieldGroup ;
+    mu:uuid "81e12e46-5a19-4911-a9df-cea6ec135ca1";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/fb21d14b-734b-48f4-bd4e-888163fd08e8>
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuursorgaanClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e00000a> # Districtsraad
+      ] ;
+    form:hasFieldGroup fieldGroups:ea030090-ed7d-477d-a94d-ff0797c757ac .###########Rechtspositieregeling-(RPR)###########
+
+fieldGroups:02ffc029-d60c-49f7-8b13-5250a41615a6 a form:FieldGroup ;
+    mu:uuid "02ffc029-d60c-49f7-8b13-5250a41615a6" ; 
+    form:hasField 
+                      ###Datum-zitting/besluit###
+                      fields:3dd6ed93-40f7-4d70-a6cb-f4de53dc8bfb,
+
+                      ###Datum-zitting/besluit###
+                      fields:3dd6ed93-40f7-4d70-a6cb-f4de53dc8bfb,
+
+                      ###Welk-beslissingsorgaan-nam-het-besluit?###
+                      fields:4c7820f0-4011-4ab4-a16a-e128800e11bc,
+
+                      ###Datum-van-publicatie-op-webtoepassing###
+                      fields:49dbe1be-877a-4890-8465-1510ff18ce18,
+
+                      ###Type RemoteDataObject or FileDataObject###
+                      fields:355fe001-cdca-48cc-8a6e-88b3aab09874,
+
+                      ### RemoteDataObject/url ###
+                      fields:d0052f0d-90bc-4543-a6b0-e90a1c1117db,
+
+                      ### Bestuursorgaan classificatie code [hidden input] ###
+                      fields:303545a6-705b-43b3-86b7-b96436524be9,
+
+                      ### Bestuurseenheid classificatie code [hidden input] ###
+                      fields:ac32a491-4b5c-4a7e-973f-fad6127c9433.
+
+fields:0827fafe-ad19-49e1-8b2e-105d2c08a54a form:hasConditionalFieldGroup fields:d4a51632-72d3-459b-b6e5-0d87fbac188a.
+
+fields:d4a51632-72d3-459b-b6e5-0d87fbac188a a form:ConditionalFieldGroup ;
+    mu:uuid "d4a51632-72d3-459b-b6e5-0d87fbac188a";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/fb21d14b-734b-48f4-bd4e-888163fd08e8>
+      ] ;
+    form:hasFieldGroup fieldGroups:02ffc029-d60c-49f7-8b13-5250a41615a6 .
+
+fieldGroups:c3e3fc6f-0635-4b14-b927-685c3a78a36d a form:FieldGroup ;
+    mu:uuid "c3e3fc6f-0635-4b14-b927-685c3a78a36d" ;
+    form:hasField
+
+                      ###Links-naar-documenten###
+                      fields:1e0f541f-61e9-43a7-bc5f-612eb44f52bb,
+
+                      ###Bestanden###
+                      fields:c7c5a589-0785-4032-a4bd-ee589add3c39.
+
+# this field is the custom bestuursorgaan selector
+fields:4c7820f0-4011-4ab4-a16a-e128800e11bc form:hasConditionalFieldGroup fields:2b60bbd2-ab80-4916-9a50-26c451c8bc90.
+
+fields:2b60bbd2-ab80-4916-9a50-26c451c8bc90 a form:ConditionalFieldGroup ;
+    mu:uuid "2b60bbd2-ab80-4916-9a50-26c451c8bc90";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/fb21d14b-734b-48f4-bd4e-888163fd08e8>
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuursorgaanClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000005> # gemeenteraad
+      ] ;
+    form:hasFieldGroup fieldGroups:c3e3fc6f-0635-4b14-b927-685c3a78a36d .fieldGroups:8f7d2f14-e190-4b27-ad5d-621b6c38962a a form:FieldGroup ;
+    mu:uuid "8f7d2f14-e190-4b27-ad5d-621b6c38962a" ;
+    form:hasField
+
+                      ###Links-naar-documenten###
+                      fields:1e0f541f-61e9-43a7-bc5f-612eb44f52bb,
+
+                      ###Bestanden###
+                      fields:c7c5a589-0785-4032-a4bd-ee589add3c39.
+
+# this field is the custom bestuursorgaan selector
+fields:4c7820f0-4011-4ab4-a16a-e128800e11bc form:hasConditionalFieldGroup fields:0f4ecac3-4d53-4e40-bf1d-92c75f3cf60c.
+
+fields:0f4ecac3-4d53-4e40-bf1d-92c75f3cf60c a form:ConditionalFieldGroup ;
+    mu:uuid "0f4ecac3-4d53-4e40-bf1d-92c75f3cf60c";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/fb21d14b-734b-48f4-bd4e-888163fd08e8>
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuursorgaanClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/180a2fba-6ca9-4766-9b94-82006bb9c709> # Gouverneur
+      ] ;
+    form:hasFieldGroup fieldGroups:8f7d2f14-e190-4b27-ad5d-621b6c38962a .fieldGroups:36ae70e1-d1e0-4aa2-a2cd-b8145cf0a078 a form:FieldGroup ;
+    mu:uuid "36ae70e1-d1e0-4aa2-a2cd-b8145cf0a078" ;
+    form:hasField
+
+                      ###Links-naar-documenten###
+                      fields:1e0f541f-61e9-43a7-bc5f-612eb44f52bb,
+
+                      ###Bestanden###
+                      fields:c7c5a589-0785-4032-a4bd-ee589add3c39.
+
+# this field is the custom bestuursorgaan selector
+fields:4c7820f0-4011-4ab4-a16a-e128800e11bc form:hasConditionalFieldGroup fields:3ba41f88-172f-4091-a662-60c45c4ef618.
+
+fields:3ba41f88-172f-4091-a662-60c45c4ef618 a form:ConditionalFieldGroup ;
+    mu:uuid "3ba41f88-172f-4091-a662-60c45c4ef618";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/fb21d14b-734b-48f4-bd4e-888163fd08e8>
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuursorgaanClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000007> # Raad voor Maatschappelijk Welzijn
+      ] ;
+    form:hasFieldGroup fieldGroups:36ae70e1-d1e0-4aa2-a2cd-b8145cf0a078 .fieldGroups:221c2c82-365b-4c57-896a-9643950c4412 a form:FieldGroup ;
+    mu:uuid "221c2c82-365b-4c57-896a-9643950c4412" ;
+    form:hasField
+
+                      ###Links-naar-documenten###
+                      fields:1e0f541f-61e9-43a7-bc5f-612eb44f52bb,
+
+                      ###Bestanden###
+                      fields:c7c5a589-0785-4032-a4bd-ee589add3c39.
+
+# this field is the custom bestuursorgaan selector
+fields:4c7820f0-4011-4ab4-a16a-e128800e11bc form:hasConditionalFieldGroup fields:875cbd50-102a-4972-b120-10a38528c637.
+
+fields:875cbd50-102a-4972-b120-10a38528c637 a form:ConditionalFieldGroup ;
+    mu:uuid "875cbd50-102a-4972-b120-10a38528c637";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/fb21d14b-734b-48f4-bd4e-888163fd08e8>
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuursorgaanClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e00000c> # Provincieraad
+      ] ;
+    form:hasFieldGroup fieldGroups:221c2c82-365b-4c57-896a-9643950c4412 .fieldGroups:11a7e169-3a66-4c8b-9a1d-141120f5198e a form:FieldGroup ;
+    mu:uuid "11a7e169-3a66-4c8b-9a1d-141120f5198e" ;
+    form:hasField
+
+                      ###Links-naar-documenten###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,
+
+                      ###Bestanden###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95a.
+
+# this field is the custom bestuursorgaan selector
+fields:4c7820f0-4011-4ab4-a16a-e128800e11bc form:hasConditionalFieldGroup fields:5ff1f719-02d6-4105-9e65-0863ebad24dd.
+
+fields:5ff1f719-02d6-4105-9e65-0863ebad24dd a form:ConditionalFieldGroup ;
+    mu:uuid "5ff1f719-02d6-4105-9e65-0863ebad24dd";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/fb21d14b-734b-48f4-bd4e-888163fd08e8>
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuursorgaanClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> # Raad van bestuur
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:bestuurt besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuurseenheidClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/36a82ba0-7ff1-4697-a9dd-2e94df73b721> # Autonoom gemeentebedrijf
+      ] ;
+    form:hasFieldGroup fieldGroups:11a7e169-3a66-4c8b-9a1d-141120f5198e .fieldGroups:11a7e169-3a66-4c8b-9a1d-141120f5198e a form:FieldGroup ;
+    mu:uuid "11a7e169-3a66-4c8b-9a1d-141120f5198e" ;
+    form:hasField
+
+                      ###Links-naar-documenten###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,
+
+                      ###Bestanden###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95a.
+
+# this field is the custom bestuursorgaan selector
+fields:4c7820f0-4011-4ab4-a16a-e128800e11bc form:hasConditionalFieldGroup fields:c2a97f7d-ded2-4afa-a5e5-6bd44d5cfa13.
+
+fields:c2a97f7d-ded2-4afa-a5e5-6bd44d5cfa13 a form:ConditionalFieldGroup ;
+    mu:uuid "c2a97f7d-ded2-4afa-a5e5-6bd44d5cfa13";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/fb21d14b-734b-48f4-bd4e-888163fd08e8>
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuursorgaanClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> # Raad van bestuur
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:bestuurt besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuurseenheidClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/80310756-ce0a-4a1b-9b8e-7c01b6cc7a2d> # Autonoom provinciebedrijf
+      ] ;
+    form:hasFieldGroup fieldGroups:11a7e169-3a66-4c8b-9a1d-141120f5198e .
+fieldGroups:9bf67942-3605-4ecd-8e01-3720d48e6dfc a form:FieldGroup ;
+    mu:uuid "9bf67942-3605-4ecd-8e01-3720d48e6dfc" ;
+    form:hasField
+
+                      ###Links-naar-documenten###
+                      fields:1e0f541f-61e9-43a7-bc5f-612eb44f52bb,
+
+                      ###Bestanden###
+                      fields:c7c5a589-0785-4032-a4bd-ee589add3c39.
+
+# this field is the custom bestuursorgaan selector
+fields:4c7820f0-4011-4ab4-a16a-e128800e11bc form:hasConditionalFieldGroup fields:66e740c1-e7b8-44a9-a8c1-bd3ff0bf0180.
+
+fields:66e740c1-e7b8-44a9-a8c1-bd3ff0bf0180 a form:ConditionalFieldGroup ;
+    mu:uuid "66e740c1-e7b8-44a9-a8c1-bd3ff0bf0180";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/fb21d14b-734b-48f4-bd4e-888163fd08e8>
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuursorgaanClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> # Raad van bestuur
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:bestuurt besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuurseenheidClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/d01bb1f6-2439-4e33-9c25-1fc295de2e71> # Dienstverlenende vereniging
+      ] ;
+    form:hasFieldGroup fieldGroups:9bf67942-3605-4ecd-8e01-3720d48e6dfc .fieldGroups:79ef7a50-4553-4c44-8348-c3de8972faaf a form:FieldGroup ;
+    mu:uuid "79ef7a50-4553-4c44-8348-c3de8972faaf" ;
+    form:hasField
+
+                      ###Links-naar-documenten###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,
+
+                      ###Bestanden###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95a.
+
+# this field is the custom bestuursorgaan selector
+fields:4c7820f0-4011-4ab4-a16a-e128800e11bc form:hasConditionalFieldGroup fields:edf99d78-88e0-409b-8298-5bf07f548fec.
+
+fields:edf99d78-88e0-409b-8298-5bf07f548fec a form:ConditionalFieldGroup ;
+    mu:uuid "edf99d78-88e0-409b-8298-5bf07f548fec";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/fb21d14b-734b-48f4-bd4e-888163fd08e8>
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuursorgaanClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> # Raad van bestuur
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:bestuurt besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuurseenheidClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/cc4e2d67-603b-4784-9b61-e50bac1ec089> # OCMW vereniging
+      ] ;
+    form:hasFieldGroup fieldGroups:79ef7a50-4553-4c44-8348-c3de8972faaf .fieldGroups:2dfdffd9-c252-4ad9-a01d-bd1343352022 a form:FieldGroup ;
+    mu:uuid "2dfdffd9-c252-4ad9-a01d-bd1343352022" ;
+    form:hasField
+
+                      ###Links-naar-documenten###
+                      fields:1e0f541f-61e9-43a7-bc5f-612eb44f52bb,
+
+                      ###Bestanden###
+                      fields:c7c5a589-0785-4032-a4bd-ee589add3c39.
+
+# this field is the custom bestuursorgaan selector
+fields:4c7820f0-4011-4ab4-a16a-e128800e11bc form:hasConditionalFieldGroup fields:953d7127-8f36-489e-87f6-d43247eb154e.
+
+fields:953d7127-8f36-489e-87f6-d43247eb154e a form:ConditionalFieldGroup ;
+    mu:uuid "953d7127-8f36-489e-87f6-d43247eb154e";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/fb21d14b-734b-48f4-bd4e-888163fd08e8>
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuursorgaanClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> # Raad van bestuur
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:bestuurt besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuurseenheidClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/cd93f147-3ece-4308-acab-5c5ada3ec63d> # Opdrachthoudende vereniging
+      ] ;
+    form:hasFieldGroup fieldGroups:2dfdffd9-c252-4ad9-a01d-bd1343352022 .fieldGroups:7a873844-2aad-4f00-9c11-cf4056baa2ae a form:FieldGroup ;
+    mu:uuid "7a873844-2aad-4f00-9c11-cf4056baa2ae" ;
+    form:hasField
+
+                      ###Links-naar-documenten###
+                      fields:1e0f541f-61e9-43a7-bc5f-612eb44f52bb,
+
+                      ###Bestanden###
+                      fields:c7c5a589-0785-4032-a4bd-ee589add3c39.
+
+# this field is the custom bestuursorgaan selector
+fields:4c7820f0-4011-4ab4-a16a-e128800e11bc form:hasConditionalFieldGroup fields:fd59b06f-84d2-46d6-9436-49b894995b31.
+
+fields:fd59b06f-84d2-46d6-9436-49b894995b31 a form:ConditionalFieldGroup ;
+    mu:uuid "fd59b06f-84d2-46d6-9436-49b894995b31";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/fb21d14b-734b-48f4-bd4e-888163fd08e8>
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuursorgaanClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/17e76b36-64a1-4db1-8927-def3064b4bf1> # Regionaal bestuurscomité
+      ] ;
+    form:hasFieldGroup fieldGroups:7a873844-2aad-4f00-9c11-cf4056baa2ae .fieldGroups:37ed86ab-4473-46e0-8516-dd7ecf6938aa a form:FieldGroup ;
+    mu:uuid "37ed86ab-4473-46e0-8516-dd7ecf6938aa" ;
+    form:hasField
+
+                      ###Links-naar-documenten###
+                      fields:1e0f541f-61e9-43a7-bc5f-612eb44f52bb,
+
+                      ###Bestanden###
+                      fields:c7c5a589-0785-4032-a4bd-ee589add3c39.
+
+# this field is the custom bestuursorgaan selector
+fields:4c7820f0-4011-4ab4-a16a-e128800e11bc form:hasConditionalFieldGroup fields:d1315fc9-e893-4b95-b715-ee94211a586e.
+
+fields:d1315fc9-e893-4b95-b715-ee94211a586e a form:ConditionalFieldGroup ;
+    mu:uuid "d1315fc9-e893-4b95-b715-ee94211a586e";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/fb21d14b-734b-48f4-bd4e-888163fd08e8>
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuursorgaanClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000008> # vast bureau
+      ] ;
+    form:hasFieldGroup fieldGroups:37ed86ab-4473-46e0-8516-dd7ecf6938aa .fieldGroups:8300383c-c40a-4518-af52-0307c1414237 a form:FieldGroup ;
+    mu:uuid "8300383c-c40a-4518-af52-0307c1414237" ;
+    form:hasField
+
+                      ###Links-naar-documenten###
+                      fields:1e0f541f-61e9-43a7-bc5f-612eb44f52bb,
+
+                      ###Bestanden###
+                      fields:c7c5a589-0785-4032-a4bd-ee589add3c39.
+
+# this field is the custom bestuursorgaan selector
+fields:4c7820f0-4011-4ab4-a16a-e128800e11bc form:hasConditionalFieldGroup fields:8fc61455-add6-41ae-afcf-dcea2edc6771.
+
+fields:8fc61455-add6-41ae-afcf-dcea2edc6771 a form:ConditionalFieldGroup ;
+    mu:uuid "8fc61455-add6-41ae-afcf-dcea2edc6771";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/fb21d14b-734b-48f4-bd4e-888163fd08e8>
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuursorgaanClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/53c0d8cd-f3a2-411d-bece-4bd83ae2bbc9> # Voorzitter van het Bijzonder Comité voor de Sociale Dienst
+      ] ;
+    form:hasFieldGroup fieldGroups:8300383c-c40a-4518-af52-0307c1414237 .###########Aanvullende Belasting###########
+
+fieldGroups:487e5f38-72ff-4afa-a41b-5fcd840969a7 a form:FieldGroup ;
+    mu:uuid "487e5f38-72ff-4afa-a41b-5fcd840969a7" ;
+    form:hasField
+                      ###Mar code###
+                      fields:a1b6c2e1-c1c3-45fb-84e7-cdd241a3130d,
+
+                      ###Geldt vanaf###
+                      fields:4b32c8fb-9725-4f9f-9872-b04198732483,
+
+                      ###Geldt tot####
+                      fields:3a9f6f7d-2952-4128-84cc-bc8dc3d1ee44.
+
+fields:7cd14dfd-81ff-4a5d-8374-5879c5877c4c form:hasConditionalFieldGroup fields:98b9fcb9-492c-467c-a2b5-94fc4123dd4e.
+
+fields:98b9fcb9-492c-467c-a2b5-94fc4123dd4e a form:ConditionalFieldGroup ;
+    mu:uuid "98b9fcb9-492c-467c-a2b5-94fc4123dd4e";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/3037c4f4-1c63-43ac-bfc4-b41d098b15a6> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/b2d0734d-13d0-44b4-9af8-1722933c5288>
+      ] ;
+    form:hasFieldGroup fieldGroups:487e5f38-72ff-4afa-a41b-5fcd840969a7 .###########Contantbelasting###########
+
+fieldGroups:35f82f0e-a28a-4e46-836f-5ea8b21bd36a a form:FieldGroup ;
+    mu:uuid "35f82f0e-a28a-4e46-836f-5ea8b21bd36a" ;
+    form:hasField
+                      ###Mar code###
+                      fields:ef31b839-c461-4732-b35c-a8b6c7507cf1,
+
+                      ###Geldt vanaf###
+                      fields:7793c27f-a41b-4665-a876-da9d94075a70,
+
+                      ###Geldt tot####
+                      fields:eeacea67-d327-4952-bbfa-31207823ba87.
+
+fields:7cd14dfd-81ff-4a5d-8374-5879c5877c4c form:hasConditionalFieldGroup fields:b9b99ee9-9b29-4b05-b024-79e56c5d52c9.
+
+fields:b9b99ee9-9b29-4b05-b024-79e56c5d52c9 a form:ConditionalFieldGroup ;
+    mu:uuid "b9b99ee9-9b29-4b05-b024-79e56c5d52c9";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/3037c4f4-1c63-43ac-bfc4-b41d098b15a6> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/4c22ef0a-f808-41dd-9c9f-2aff17fd851f>
+      ] ;
+    form:hasFieldGroup fieldGroups:35f82f0e-a28a-4e46-836f-5ea8b21bd36a .###########Kohierbelasting###########
+
+fieldGroups:577dcadb-89fb-4365-af2c-93a61c1b9264 a form:FieldGroup ;
+    mu:uuid "577dcadb-89fb-4365-af2c-93a61c1b9264" ;
+    form:hasField
+                      ###Mar code###
+                      fields:ef31b839-c461-4732-b35c-a8b6c7507cf1,
+
+                      ###Geldt vanaf###
+                      fields:7793c27f-a41b-4665-a876-da9d94075a70,
+
+                      ###Geldt tot####
+                      fields:eeacea67-d327-4952-bbfa-31207823ba87.
+
+fields:7cd14dfd-81ff-4a5d-8374-5879c5877c4c form:hasConditionalFieldGroup fields:0c7d6a0d-146e-40bf-b834-12941feac885.
+
+fields:0c7d6a0d-146e-40bf-b834-12941feac885 a form:ConditionalFieldGroup ;
+    mu:uuid "0c7d6a0d-146e-40bf-b834-12941feac885";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/3037c4f4-1c63-43ac-bfc4-b41d098b15a6> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/8597e056-b96d-4213-ad4c-37338f2aaf35>
+      ] ;
+    form:hasFieldGroup fieldGroups:577dcadb-89fb-4365-af2c-93a61c1b9264 .###########Belastingsreglement###########
+
+fieldGroups:ea903e93-a1c9-4542-ab11-8a274af5ee1c a form:FieldGroup ;
+    mu:uuid "ea903e93-a1c9-4542-ab11-8a274af5ee1c" ; 
+    form:hasField 
+                      ###Soort Belasting###
+                      fields:7cd14dfd-81ff-4a5d-8374-5879c5877c4c,
+
+                      ###Differentiatie###
+                      fields:f3c1f62e-0fc6-4440-8208-7a0ef49fb28c,
+
+                      ###TaxRate Type###
+                      fields:eaf71eec-6ca8-4f63-b4a6-adfe4f21651b,
+
+                      ###Vlabel opcentiem###
+                      fields:1ee5132e-28c0-4292-9fe6-24c7be456580.
+
+fields:e834ec56-2db3-43d8-8a54-baf6cc0463c6 form:hasConditionalFieldGroup fields:92a18a28-444e-49e9-8b45-4967c5c18d66.
+
+fields:92a18a28-444e-49e9-8b45-4967c5c18d66 a form:ConditionalFieldGroup ;
+    mu:uuid "92a18a28-444e-49e9-8b45-4967c5c18d66";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/c93ccd41-aee7-488f-86d3-038de890d05a> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/efa4ec5a-b006-453f-985f-f986ebae11bc>
+      ] ;
+    form:hasFieldGroup fieldGroups:ea903e93-a1c9-4542-ab11-8a274af5ee1c .
+
+###########Reglementen-en-verordeningen###########
+
+fieldGroups:a5964067-defb-48ca-8cb2-04db3d6ecd13 a form:FieldGroup ;
+    mu:uuid "a5964067-defb-48ca-8cb2-04db3d6ecd13" ; 
+    form:hasField 
+                      ###Datum-van-publicatie-op-webtoepassing###
+                      fields:49dbe1be-877a-4890-8465-1510ff18ce18,
+
+                      ###Datum-zitting/besluit###
+                      fields:3dd6ed93-40f7-4d70-a6cb-f4de53dc8bfb,
+
+                      ###Datum-zitting/besluit###
+                      fields:3dd6ed93-40f7-4d70-a6cb-f4de53dc8bfb,
+
+                      ###Type-reglement/verordening###
+                      fields:e834ec56-2db3-43d8-8a54-baf6cc0463c6,
+
+                      ###Welk-beslissingsorgaan-nam-het-besluit?###
+                      fields:4c7820f0-4011-4ab4-a16a-e128800e11bc,
+
+                      ###Links-naar-documenten###
+                      fields:1e0f541f-61e9-43a7-bc5f-612eb44f52bb,
+
+                      ###Bestanden###
+                      fields:c7c5a589-0785-4032-a4bd-ee589add3c39,
+
+                      ###Type RemoteDataObject or FileDataObject###
+                      fields:355fe001-cdca-48cc-8a6e-88b3aab09874,
+
+                      ### RemoteDataObject/url ###
+                      fields:d0052f0d-90bc-4543-a6b0-e90a1c1117db.
+                      
+fields:0827fafe-ad19-49e1-8b2e-105d2c08a54a form:hasConditionalFieldGroup fields:4f8e79e3-3b13-4a6a-b6e0-1909ab6cfa2a.
+
+fields:4f8e79e3-3b13-4a6a-b6e0-1909ab6cfa2a a form:ConditionalFieldGroup ;
+    mu:uuid "4f8e79e3-3b13-4a6a-b6e0-1909ab6cfa2a";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/67378dd0-5413-474b-8996-d992ef81637a>
+      ] ;
+    form:hasFieldGroup fieldGroups:a5964067-defb-48ca-8cb2-04db3d6ecd13 .
+
+fieldGroups:0b7f1467-0759-46d8-a1a1-b0ec4952ff19 a form:FieldGroup ;
+    mu:uuid "0b7f1467-0759-46d8-a1a1-b0ec4952ff19" ;
+    form:hasField
+
+                      ###Links-naar-documenten###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,
+
+                      ###Bestanden###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95a.
+
+# this field is the custom bestuursorgaan selector
+fields:4c7820f0-4011-4ab4-a16a-e128800e11bc form:hasConditionalFieldGroup fields:4327b770-e503-4786-9254-436014e8dffe.
+
+fields:4327b770-e503-4786-9254-436014e8dffe a form:ConditionalFieldGroup ;
+    mu:uuid "4327b770-e503-4786-9254-436014e8dffe";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/b25faa84-3ab5-47ae-98c0-1b389c77b827> # Schorsing beslissing eredienstbesturen
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuursorgaanClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/4955bd72cd0e4eb895fdbfab08da0284> # burgemeester
+      ] ;
+    form:hasFieldGroup fieldGroups:0b7f1467-0759-46d8-a1a1-b0ec4952ff19 .fieldGroups:8cde44c1-5173-40ce-95c9-56838f3f8907 a form:FieldGroup ;
+    mu:uuid "8cde44c1-5173-40ce-95c9-56838f3f8907" ;
+    form:hasField
+
+                      ###Links-naar-documenten###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,
+
+                      ###Bestanden###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95a.
+
+# this field is the custom bestuursorgaan selector
+fields:4c7820f0-4011-4ab4-a16a-e128800e11bc form:hasConditionalFieldGroup fields:4395c2e7-467a-44af-83dc-5ef1e1b912fc.
+
+fields:4395c2e7-467a-44af-83dc-5ef1e1b912fc a form:ConditionalFieldGroup ;
+    mu:uuid "4395c2e7-467a-44af-83dc-5ef1e1b912fc";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/b25faa84-3ab5-47ae-98c0-1b389c77b827> # Schorsing beslissing eredienstbesturen
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuursorgaanClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000006> # college van schepenen en burgermeester
+      ] ;
+    form:hasFieldGroup fieldGroups:8cde44c1-5173-40ce-95c9-56838f3f8907 .fieldGroups:b7f8c30e-2cee-49c5-8472-9e66f5872fe4 a form:FieldGroup ;
+    mu:uuid "b7f8c30e-2cee-49c5-8472-9e66f5872fe4" ;
+    form:hasField
+
+                      ###Links-naar-documenten###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,
+
+                      ###Bestanden###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95a.
+
+# this field is the custom bestuursorgaan selector
+fields:4c7820f0-4011-4ab4-a16a-e128800e11bc form:hasConditionalFieldGroup fields:3c93de27-86fc-4cbd-92f0-e93a39fe49bd.
+
+fields:3c93de27-86fc-4cbd-92f0-e93a39fe49bd a form:ConditionalFieldGroup ;
+    mu:uuid "3c93de27-86fc-4cbd-92f0-e93a39fe49bd";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/b25faa84-3ab5-47ae-98c0-1b389c77b827> # Schorsing beslissing eredienstbesturen
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuursorgaanClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e00000d> # deputatie
+      ] ;
+    form:hasFieldGroup fieldGroups:b7f8c30e-2cee-49c5-8472-9e66f5872fe4 .
+
+
+###########Schorsing-beslissing-eredienstbesturen###########
+
+fieldGroups:6745c3c5-ed83-45e2-a9e7-ca77c18f0d05 a form:FieldGroup ;
+    mu:uuid "6745c3c5-ed83-45e2-a9e7-ca77c18f0d05" ; 
+    form:hasField 
+                      ###Eredienst selector###
+                      fields:7d0a105f-0c7e-49ab-9ab8-68d5381b3b8b,
+
+                      ###Datum-zitting/besluit###
+                      fields:3dd6ed93-40f7-4d70-a6cb-f4de53dc8bfb,
+
+                      ###Datum-zitting/besluit###
+                      fields:3dd6ed93-40f7-4d70-a6cb-f4de53dc8bfb,
+
+                      ###Welk-beslissingsorgaan-nam-het-besluit?###
+                      fields:4c7820f0-4011-4ab4-a16a-e128800e11bc,
+
+                      ###Type RemoteDataObject or FileDataObject###
+                      fields:355fe001-cdca-48cc-8a6e-88b3aab09874,
+
+                      ### RemoteDataObject/url ###
+                      fields:d0052f0d-90bc-4543-a6b0-e90a1c1117db,
+                      
+                      ### Bestuursorgaan classificatie code [hidden input] ###
+                      fields:303545a6-705b-43b3-86b7-b96436524be9,
+
+                      ### Bestuurseenheid classificatie code [hidden input] ###
+                      fields:ac32a491-4b5c-4a7e-973f-fad6127c9433.
+
+fields:0827fafe-ad19-49e1-8b2e-105d2c08a54a form:hasConditionalFieldGroup fields:40f6d026-11f0-44b3-8594-58210f2860c5.
+
+fields:40f6d026-11f0-44b3-8594-58210f2860c5 a form:ConditionalFieldGroup ;
+    mu:uuid "40f6d026-11f0-44b3-8594-58210f2860c5";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/b25faa84-3ab5-47ae-98c0-1b389c77b827> # Schorsing beslissing eredienstbesturen
+      ] ;
+    form:hasFieldGroup fieldGroups:6745c3c5-ed83-45e2-a9e7-ca77c18f0d05 .
+
+fieldGroups:bd599584-a03b-4930-9a1c-f9d58fb49737 a form:FieldGroup ;
+    mu:uuid "bd599584-a03b-4930-9a1c-f9d58fb49737" ;
+    form:hasField
+
+                      ###Links-naar-documenten###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,
+
+                      ###Bestanden###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95a.
+
+# this field is the custom bestuursorgaan selector
+fields:4c7820f0-4011-4ab4-a16a-e128800e11bc form:hasConditionalFieldGroup fields:6a5b0035-bf12-409f-bd84-2b7c570fd2d5.
+
+fields:6a5b0035-bf12-409f-bd84-2b7c570fd2d5 a form:ConditionalFieldGroup ;
+    mu:uuid "6a5b0035-bf12-409f-bd84-2b7c570fd2d5";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/b25faa84-3ab5-47ae-98c0-1b389c77b827> # Schorsing beslissing eredienstbesturen
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuursorgaanClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000005> # gemeenteraad
+      ] ;
+    form:hasFieldGroup fieldGroups:bd599584-a03b-4930-9a1c-f9d58fb49737 .fieldGroups:b497bac0-5348-4a56-9b72-94a93bca9b97 a form:FieldGroup ;
+    mu:uuid "b497bac0-5348-4a56-9b72-94a93bca9b97" ;
+    form:hasField
+
+                      ###Links-naar-documenten###
+                      fields:1e0f541f-61e9-43a7-bc5f-612eb44f52bb,
+
+                      ###Bestanden###
+                      fields:c7c5a589-0785-4032-a4bd-ee589add3c39.
+
+# this field is the custom bestuursorgaan selector
+fields:4c7820f0-4011-4ab4-a16a-e128800e11bc form:hasConditionalFieldGroup fields:a4d84439-5c44-4c3f-8e26-4b681407d579.
+
+fields:a4d84439-5c44-4c3f-8e26-4b681407d579 a form:ConditionalFieldGroup ;
+    mu:uuid "a4d84439-5c44-4c3f-8e26-4b681407d579";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/b25faa84-3ab5-47ae-98c0-1b389c77b827> # Schorsing beslissing eredienstbesturen
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuursorgaanClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/180a2fba-6ca9-4766-9b94-82006bb9c709> # Gouverneur
+      ] ;
+    form:hasFieldGroup fieldGroups:b497bac0-5348-4a56-9b72-94a93bca9b97 .fieldGroups:0490f35b-513d-47f2-be5d-1f59e19182bc a form:FieldGroup ;
+    mu:uuid "0490f35b-513d-47f2-be5d-1f59e19182bc" ;
+    form:hasField
+
+                      ###Links-naar-documenten###
+                      fields:1e0f541f-61e9-43a7-bc5f-612eb44f52bb,
+
+                      ###Bestanden###
+                      fields:c7c5a589-0785-4032-a4bd-ee589add3c39.
+
+# this field is the custom bestuursorgaan selector
+fields:4c7820f0-4011-4ab4-a16a-e128800e11bc form:hasConditionalFieldGroup fields:24c532a9-c890-4eaa-bb71-3655f4c62ab4.
+
+fields:24c532a9-c890-4eaa-bb71-3655f4c62ab4 a form:ConditionalFieldGroup ;
+    mu:uuid "24c532a9-c890-4eaa-bb71-3655f4c62ab4";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/b25faa84-3ab5-47ae-98c0-1b389c77b827> # Schorsing beslissing eredienstbesturen
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuursorgaanClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e00000c> # Provincieraad
+      ] ;
+    form:hasFieldGroup fieldGroups:0490f35b-513d-47f2-be5d-1f59e19182bc .
+
+###########Statutenwijziging-IGS###########
+
+fieldGroups:81f3de49-f87b-46a7-97ad-8d3c1ba34f9d a form:FieldGroup ;
+    mu:uuid "81f3de49-f87b-46a7-97ad-8d3c1ba34f9d" ; 
+    form:hasField 
+                      ###Ondernemingsnummer-betreffend-bedrijf/bestuur###
+                      fields:6ffb0ed7-769a-41e4-b5a9-f6fb0287b235,
+
+                      ###Naam-betreffend-bedrijf/bestuur###
+                      fields:78bfbd91-0778-4573-a52d-4c53b3c512eb,
+
+                      ###Datum-zitting/besluit###
+                      fields:3dd6ed93-40f7-4d70-a6cb-f4de53dc8bfb,
+
+                      ###Datum-zitting/besluit###
+                      fields:3dd6ed93-40f7-4d70-a6cb-f4de53dc8bfb,
+
+                      ###Datum-van-publicatie-op-webtoepassing###
+                      fields:49dbe1be-877a-4890-8465-1510ff18ce18,
+
+                      ###Ondernemingsnummer-betreffend-bedrijf/bestuur###
+                      fields:6ffb0ed7-769a-41e4-b5a9-f6fb0287b235,
+
+                      ###Naam-betreffend-bedrijf/bestuur###
+                      fields:78bfbd91-0778-4573-a52d-4c53b3c512eb,
+
+                      ###Welk-beslissingsorgaan-nam-het-besluit?###
+                      fields:4c7820f0-4011-4ab4-a16a-e128800e11bc,
+
+                      ###Links-naar-documenten###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,
+
+                      ###Bestanden###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95a,
+
+                      ###Type RemoteDataObject or FileDataObject###
+                      fields:355fe001-cdca-48cc-8a6e-88b3aab09874,
+
+                      ### RemoteDataObject/url ###
+                      fields:d0052f0d-90bc-4543-a6b0-e90a1c1117db.
+                      
+fields:0827fafe-ad19-49e1-8b2e-105d2c08a54a form:hasConditionalFieldGroup fields:8f4d113b-ac51-4579-a2d7-ac77caedc303.
+
+fields:8f4d113b-ac51-4579-a2d7-ac77caedc303 a form:ConditionalFieldGroup ;
+    mu:uuid "8f4d113b-ac51-4579-a2d7-ac77caedc303";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/dbc58656-b0a5-4e43-8e9e-701acb75f9b0>
+      ] ;
+    form:hasFieldGroup fieldGroups:81f3de49-f87b-46a7-97ad-8d3c1ba34f9d .
+
+fieldGroups:374b83d5-0c4d-430f-a94c-d6996c492d96 a form:FieldGroup ;
+    mu:uuid "374b83d5-0c4d-430f-a94c-d6996c492d96" ;
+    form:hasField
+
+                      ###Links-naar-documenten###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,
+
+                      ###Bestanden###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95a.
+
+# this field is the custom bestuursorgaan selector
+fields:4c7820f0-4011-4ab4-a16a-e128800e11bc form:hasConditionalFieldGroup fields:352215b8-51d1-4b49-a95c-58c580250798.
+
+fields:352215b8-51d1-4b49-a95c-58c580250798 a form:ConditionalFieldGroup ;
+    mu:uuid "352215b8-51d1-4b49-a95c-58c580250798";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/e27ef237-29de-49b8-be22-4ee2ab2d4e5b> # Toetreding rechtspersoon
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuursorgaanClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> # Algemene vergadering
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:bestuurt besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuurseenheidClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/80310756-ce0a-4a1b-9b8e-7c01b6cc7a2d> # Autonoom provinciebedrijf
+      ] ;
+    form:hasFieldGroup fieldGroups:374b83d5-0c4d-430f-a94c-d6996c492d96 .fieldGroups:524cbc11-b06e-4e2a-9438-2898eff8465c a form:FieldGroup ;
+    mu:uuid "524cbc11-b06e-4e2a-9438-2898eff8465c" ;
+    form:hasField
+
+                      ###Links-naar-documenten###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,
+
+                      ###Bestanden###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95a.
+
+# this field is the custom bestuursorgaan selector
+fields:4c7820f0-4011-4ab4-a16a-e128800e11bc form:hasConditionalFieldGroup fields:b855ce14-dba1-470f-9ffd-9a28bae72f4f.
+
+fields:b855ce14-dba1-470f-9ffd-9a28bae72f4f a form:ConditionalFieldGroup ;
+    mu:uuid "b855ce14-dba1-470f-9ffd-9a28bae72f4f";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/e27ef237-29de-49b8-be22-4ee2ab2d4e5b> # Toetreding rechtspersoon
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuursorgaanClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> # Algemene vergadering
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:bestuurt besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuurseenheidClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/d01bb1f6-2439-4e33-9c25-1fc295de2e71> # Dienstverlenende vereniging
+      ] ;
+    form:hasFieldGroup fieldGroups:524cbc11-b06e-4e2a-9438-2898eff8465c .fieldGroups:03d1de1c-a093-483a-a0c7-34e4e391803f a form:FieldGroup ;
+    mu:uuid "03d1de1c-a093-483a-a0c7-34e4e391803f" ;
+    form:hasField
+
+                      ###Links-naar-documenten###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,
+
+                      ###Bestanden###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95a.
+
+# this field is the custom bestuursorgaan selector
+fields:4c7820f0-4011-4ab4-a16a-e128800e11bc form:hasConditionalFieldGroup fields:2bf6d586-63f4-4b82-a4f5-957e80fee56c.
+
+fields:2bf6d586-63f4-4b82-a4f5-957e80fee56c a form:ConditionalFieldGroup ;
+    mu:uuid "2bf6d586-63f4-4b82-a4f5-957e80fee56c";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/e27ef237-29de-49b8-be22-4ee2ab2d4e5b> # Toetreding rechtspersoon
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuursorgaanClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> # Algemene vergadering
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:bestuurt besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuurseenheidClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/cc4e2d67-603b-4784-9b61-e50bac1ec089> # OCMW vereniging
+      ] ;
+    form:hasFieldGroup fieldGroups:03d1de1c-a093-483a-a0c7-34e4e391803f .fieldGroups:3ab7215d-cf4d-4659-b7bd-82eb8e6deac5 a form:FieldGroup ;
+    mu:uuid "3ab7215d-cf4d-4659-b7bd-82eb8e6deac5" ;
+    form:hasField
+
+                      ###Links-naar-documenten###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,
+
+                      ###Bestanden###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95a.
+
+# this field is the custom bestuursorgaan selector
+fields:4c7820f0-4011-4ab4-a16a-e128800e11bc form:hasConditionalFieldGroup fields:acba2cdb-526f-4a04-9cd3-ead1f944a777.
+
+fields:acba2cdb-526f-4a04-9cd3-ead1f944a777 a form:ConditionalFieldGroup ;
+    mu:uuid "acba2cdb-526f-4a04-9cd3-ead1f944a777";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/e27ef237-29de-49b8-be22-4ee2ab2d4e5b> # Toetreding rechtspersoon
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuursorgaanClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> # Algemene vergadering
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:bestuurt besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuurseenheidClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/cd93f147-3ece-4308-acab-5c5ada3ec63d> # Opdrachthoudende vereniging
+      ] ;
+    form:hasFieldGroup fieldGroups:3ab7215d-cf4d-4659-b7bd-82eb8e6deac5 .fieldGroups:90d7f676-31cb-4d25-a334-af2b3617c1ff a form:FieldGroup ;
+    mu:uuid "90d7f676-31cb-4d25-a334-af2b3617c1ff" ;
+    form:hasField
+
+                      ###Links-naar-documenten###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,
+
+                      ###Bestanden###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95a.
+
+# this field is the custom bestuursorgaan selector
+fields:4c7820f0-4011-4ab4-a16a-e128800e11bc form:hasConditionalFieldGroup fields:b81ceedc-52fb-45b2-9b78-5e8ab96c83ac.
+
+fields:b81ceedc-52fb-45b2-9b78-5e8ab96c83ac a form:ConditionalFieldGroup ;
+    mu:uuid "b81ceedc-52fb-45b2-9b78-5e8ab96c83ac";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/e27ef237-29de-49b8-be22-4ee2ab2d4e5b> # Toetreding rechtspersoon
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuursorgaanClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/0dbc70ec-6be9-4997-b8e1-11b6c0542382> # Bevoegd beslissingsorgaan
+      ] ;
+    form:hasFieldGroup fieldGroups:90d7f676-31cb-4d25-a334-af2b3617c1ff .fieldGroups:1b71dc03-a09b-4ef7-93a8-228da4f282d9 a form:FieldGroup ;
+    mu:uuid "1b71dc03-a09b-4ef7-93a8-228da4f282d9" ;
+    form:hasField
+
+                      ###Links-naar-documenten###
+                      fields:1e0f541f-61e9-43a7-bc5f-612eb44f52bb,
+
+                      ###Bestanden###
+                      fields:c7c5a589-0785-4032-a4bd-ee589add3c39.
+
+# this field is the custom bestuursorgaan selector
+fields:4c7820f0-4011-4ab4-a16a-e128800e11bc form:hasConditionalFieldGroup fields:80138be1-ce7a-4805-aa81-6adddafc2e39.
+
+fields:80138be1-ce7a-4805-aa81-6adddafc2e39 a form:ConditionalFieldGroup ;
+    mu:uuid "80138be1-ce7a-4805-aa81-6adddafc2e39";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/e27ef237-29de-49b8-be22-4ee2ab2d4e5b> # Toetreding rechtspersoon
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuursorgaanClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000009> # Bijzonder Comité voor de Sociale Dienst
+      ] ;
+    form:hasFieldGroup fieldGroups:1b71dc03-a09b-4ef7-93a8-228da4f282d9 .fieldGroups:1406df40-79d8-4f86-84ab-6603996c3959 a form:FieldGroup ;
+    mu:uuid "1406df40-79d8-4f86-84ab-6603996c3959" ;
+    form:hasField
+
+                      ###Links-naar-documenten###
+                      fields:1e0f541f-61e9-43a7-bc5f-612eb44f52bb,
+
+                      ###Bestanden###
+                      fields:c7c5a589-0785-4032-a4bd-ee589add3c39.
+
+# this field is the custom bestuursorgaan selector
+fields:4c7820f0-4011-4ab4-a16a-e128800e11bc form:hasConditionalFieldGroup fields:6c43dbea-c32b-41c6-a26e-de03222af855.
+
+fields:6c43dbea-c32b-41c6-a26e-de03222af855 a form:ConditionalFieldGroup ;
+    mu:uuid "6c43dbea-c32b-41c6-a26e-de03222af855";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/e27ef237-29de-49b8-be22-4ee2ab2d4e5b> # Toetreding rechtspersoon
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuursorgaanClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e00000d> # deputatie
+      ] ;
+    form:hasFieldGroup fieldGroups:1406df40-79d8-4f86-84ab-6603996c3959 .fieldGroups:851eb1eb-1b4d-44f4-8452-4941c64fc08d a form:FieldGroup ;
+    mu:uuid "851eb1eb-1b4d-44f4-8452-4941c64fc08d" ;
+    form:hasField
+
+                      ###Links-naar-documenten###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,
+
+                      ###Bestanden###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95a.
+
+# this field is the custom bestuursorgaan selector
+fields:4c7820f0-4011-4ab4-a16a-e128800e11bc form:hasConditionalFieldGroup fields:849a8f12-adc7-43ec-98d1-cdcc3866e846.
+
+fields:849a8f12-adc7-43ec-98d1-cdcc3866e846 a form:ConditionalFieldGroup ;
+    mu:uuid "849a8f12-adc7-43ec-98d1-cdcc3866e846";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/e27ef237-29de-49b8-be22-4ee2ab2d4e5b> # Toetreding rechtspersoon
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuursorgaanClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5733254e-73ff-4844-8d43-7afb7ec726e8> # directiecomité
+      ] ;
+    form:hasFieldGroup fieldGroups:851eb1eb-1b4d-44f4-8452-4941c64fc08d .
+
+###########Toetreding-rechtspersoon###########
+
+fieldGroups:46888726-9bc4-49ac-a0ef-848e37731a13 a form:FieldGroup ;
+    mu:uuid "46888726-9bc4-49ac-a0ef-848e37731a13" ; 
+    form:hasField 
+                      ###Ondernemingsnummer-betreffend-bedrijf/bestuur###
+                      fields:6ffb0ed7-769a-41e4-b5a9-f6fb0287b235,
+
+                      ###Naam-betreffend-bedrijf/bestuur###
+                      fields:78bfbd91-0778-4573-a52d-4c53b3c512eb,
+
+                      ###Datum-zitting/besluit###
+                      fields:3dd6ed93-40f7-4d70-a6cb-f4de53dc8bfb,
+
+                      ###Datum-zitting/besluit###
+                      fields:3dd6ed93-40f7-4d70-a6cb-f4de53dc8bfb,
+
+                      ###Welk-beslissingsorgaan-nam-het-besluit?###
+                      fields:4c7820f0-4011-4ab4-a16a-e128800e11bc,
+
+                      ###Datum-van-publicatie-op-webtoepassing###
+                      fields:49dbe1be-877a-4890-8465-1510ff18ce18,
+
+                      ###Ondernemingsnummer-betreffend-bedrijf/bestuur###
+                      fields:6ffb0ed7-769a-41e4-b5a9-f6fb0287b235,
+
+                      ###Naam-betreffend-bedrijf/bestuur###
+                      fields:78bfbd91-0778-4573-a52d-4c53b3c512eb,
+
+                      ###Type RemoteDataObject or FileDataObject###
+                      fields:355fe001-cdca-48cc-8a6e-88b3aab09874,
+
+                      ### RemoteDataObject/url ###
+                      fields:d0052f0d-90bc-4543-a6b0-e90a1c1117db,
+
+                      ### Bestuursorgaan classificatie code [hidden input] ###
+                      fields:303545a6-705b-43b3-86b7-b96436524be9,
+
+                      ### Bestuurseenheid classificatie code [hidden input] ###
+                      fields:ac32a491-4b5c-4a7e-973f-fad6127c9433.
+                      
+fields:0827fafe-ad19-49e1-8b2e-105d2c08a54a form:hasConditionalFieldGroup fields:4d879983-4c39-4742-a3af-690ca3b84004.
+
+fields:4d879983-4c39-4742-a3af-690ca3b84004 a form:ConditionalFieldGroup ;
+    mu:uuid "4d879983-4c39-4742-a3af-690ca3b84004";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/e27ef237-29de-49b8-be22-4ee2ab2d4e5b> # Toetreding rechtspersoon
+      ] ;
+    form:hasFieldGroup fieldGroups:46888726-9bc4-49ac-a0ef-848e37731a13 .
+
+fieldGroups:a7635bcc-0470-447a-bc90-6086c168e914 a form:FieldGroup ;
+    mu:uuid "a7635bcc-0470-447a-bc90-6086c168e914" ;
+    form:hasField
+
+                      ###Links-naar-documenten###
+                      fields:1e0f541f-61e9-43a7-bc5f-612eb44f52bb,
+
+                      ###Bestanden###
+                      fields:c7c5a589-0785-4032-a4bd-ee589add3c39.
+
+# this field is the custom bestuursorgaan selector
+fields:4c7820f0-4011-4ab4-a16a-e128800e11bc form:hasConditionalFieldGroup fields:0840e833-0774-43e6-ba40-d13cf90650fb.
+
+fields:0840e833-0774-43e6-ba40-d13cf90650fb a form:ConditionalFieldGroup ;
+    mu:uuid "0840e833-0774-43e6-ba40-d13cf90650fb";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/e27ef237-29de-49b8-be22-4ee2ab2d4e5b> # Toetreding rechtspersoon
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuursorgaanClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/180a2fba-6ca9-4766-9b94-82006bb9c709> # Gouverneur
+      ] ;
+    form:hasFieldGroup fieldGroups:a7635bcc-0470-447a-bc90-6086c168e914 .fieldGroups:7f2c6f5b-4c31-4a37-8010-8506b1560a93 a form:FieldGroup ;
+    mu:uuid "7f2c6f5b-4c31-4a37-8010-8506b1560a93" ;
+    form:hasField
+
+                      ###Links-naar-documenten###
+                      fields:1e0f541f-61e9-43a7-bc5f-612eb44f52bb,
+
+                      ###Bestanden###
+                      fields:c7c5a589-0785-4032-a4bd-ee589add3c39.
+
+# this field is the custom bestuursorgaan selector
+fields:4c7820f0-4011-4ab4-a16a-e128800e11bc form:hasConditionalFieldGroup fields:3c7f233c-68da-4bd0-bf6f-2289228a26f6.
+
+fields:3c7f233c-68da-4bd0-bf6f-2289228a26f6 a form:ConditionalFieldGroup ;
+    mu:uuid "3c7f233c-68da-4bd0-bf6f-2289228a26f6";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/e27ef237-29de-49b8-be22-4ee2ab2d4e5b> # Toetreding rechtspersoon
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuursorgaanClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000007> # Raad voor Maatschappelijk Welzijn
+      ] ;
+    form:hasFieldGroup fieldGroups:7f2c6f5b-4c31-4a37-8010-8506b1560a93 .fieldGroups:51c7fb26-37e7-4207-8822-a057a97a689f a form:FieldGroup ;
+    mu:uuid "51c7fb26-37e7-4207-8822-a057a97a689f" ;
+    form:hasField
+
+                      ###Links-naar-documenten###
+                      fields:1e0f541f-61e9-43a7-bc5f-612eb44f52bb,
+
+                      ###Bestanden###
+                      fields:c7c5a589-0785-4032-a4bd-ee589add3c39.
+
+# this field is the custom bestuursorgaan selector
+fields:4c7820f0-4011-4ab4-a16a-e128800e11bc form:hasConditionalFieldGroup fields:9c069a31-994d-4ba8-b905-fa705c72f92a.
+
+fields:9c069a31-994d-4ba8-b905-fa705c72f92a a form:ConditionalFieldGroup ;
+    mu:uuid "9c069a31-994d-4ba8-b905-fa705c72f92a";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/e27ef237-29de-49b8-be22-4ee2ab2d4e5b> # Toetreding rechtspersoon
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuursorgaanClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e00000c> # Provincieraad
+      ] ;
+    form:hasFieldGroup fieldGroups:51c7fb26-37e7-4207-8822-a057a97a689f .fieldGroups:bf3c5052-7bfd-4af8-a468-5010e33dfa35 a form:FieldGroup ;
+    mu:uuid "bf3c5052-7bfd-4af8-a468-5010e33dfa35" ;
+    form:hasField
+
+                      ###Links-naar-documenten###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,
+
+                      ###Bestanden###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95a.
+
+# this field is the custom bestuursorgaan selector
+fields:4c7820f0-4011-4ab4-a16a-e128800e11bc form:hasConditionalFieldGroup fields:d37728e7-b944-4a74-ac54-42c92e6c6d55.
+
+fields:d37728e7-b944-4a74-ac54-42c92e6c6d55 a form:ConditionalFieldGroup ;
+    mu:uuid "d37728e7-b944-4a74-ac54-42c92e6c6d55";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/e27ef237-29de-49b8-be22-4ee2ab2d4e5b> # Toetreding rechtspersoon
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuursorgaanClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> # Raad van bestuur
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:bestuurt besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuurseenheidClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/80310756-ce0a-4a1b-9b8e-7c01b6cc7a2d> # Autonoom provinciebedrijf
+      ] ;
+    form:hasFieldGroup fieldGroups:bf3c5052-7bfd-4af8-a468-5010e33dfa35 .fieldGroups:40e3130a-1674-44fe-b7d6-61d247614941 a form:FieldGroup ;
+    mu:uuid "40e3130a-1674-44fe-b7d6-61d247614941" ;
+    form:hasField
+
+                      ###Links-naar-documenten###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,
+
+                      ###Bestanden###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95a.
+
+# this field is the custom bestuursorgaan selector
+fields:4c7820f0-4011-4ab4-a16a-e128800e11bc form:hasConditionalFieldGroup fields:3de3d137-2e50-42dd-bbcd-57292b04d399.
+
+fields:3de3d137-2e50-42dd-bbcd-57292b04d399 a form:ConditionalFieldGroup ;
+    mu:uuid "3de3d137-2e50-42dd-bbcd-57292b04d399";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/e27ef237-29de-49b8-be22-4ee2ab2d4e5b> # Toetreding rechtspersoon
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuursorgaanClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> # Raad van bestuur
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:bestuurt besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuurseenheidClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/d01bb1f6-2439-4e33-9c25-1fc295de2e71> # Dienstverlenende vereniging
+      ] ;
+    form:hasFieldGroup fieldGroups:40e3130a-1674-44fe-b7d6-61d247614941 .fieldGroups:a8a2d3b7-54d2-4048-b371-fda94dfc0f6f a form:FieldGroup ;
+    mu:uuid "a8a2d3b7-54d2-4048-b371-fda94dfc0f6f" ;
+    form:hasField
+
+                      ###Links-naar-documenten###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,
+
+                      ###Bestanden###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95a.
+
+# this field is the custom bestuursorgaan selector
+fields:4c7820f0-4011-4ab4-a16a-e128800e11bc form:hasConditionalFieldGroup fields:e7e63f88-e605-434e-905d-4bc744289713.
+
+fields:e7e63f88-e605-434e-905d-4bc744289713 a form:ConditionalFieldGroup ;
+    mu:uuid "e7e63f88-e605-434e-905d-4bc744289713";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/e27ef237-29de-49b8-be22-4ee2ab2d4e5b> # Toetreding rechtspersoon
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuursorgaanClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> # Raad van bestuur
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:bestuurt besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuurseenheidClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/cc4e2d67-603b-4784-9b61-e50bac1ec089> # OCMW vereniging
+      ] ;
+    form:hasFieldGroup fieldGroups:a8a2d3b7-54d2-4048-b371-fda94dfc0f6f .fieldGroups:d37b24fd-dbf4-4333-86cc-ed6a82f92bd4 a form:FieldGroup ;
+    mu:uuid "d37b24fd-dbf4-4333-86cc-ed6a82f92bd4" ;
+    form:hasField
+
+                      ###Links-naar-documenten###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,
+
+                      ###Bestanden###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95a.
+
+# this field is the custom bestuursorgaan selector
+fields:4c7820f0-4011-4ab4-a16a-e128800e11bc form:hasConditionalFieldGroup fields:6b0d521e-b1a3-4b5d-bbb7-5d0c465e1cbb.
+
+fields:6b0d521e-b1a3-4b5d-bbb7-5d0c465e1cbb a form:ConditionalFieldGroup ;
+    mu:uuid "6b0d521e-b1a3-4b5d-bbb7-5d0c465e1cbb";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/e27ef237-29de-49b8-be22-4ee2ab2d4e5b> # Toetreding rechtspersoon
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuursorgaanClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> # Raad van bestuur
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:bestuurt besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuurseenheidClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/cd93f147-3ece-4308-acab-5c5ada3ec63d> # Opdrachthoudende vereniging
+      ] ;
+    form:hasFieldGroup fieldGroups:d37b24fd-dbf4-4333-86cc-ed6a82f92bd4 .fieldGroups:1ed80702-9bec-4b44-ba1f-c033ef35a018 a form:FieldGroup ;
+    mu:uuid "1ed80702-9bec-4b44-ba1f-c033ef35a018" ;
+    form:hasField
+
+                      ###Links-naar-documenten###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,
+
+                      ###Bestanden###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95a.
+
+# this field is the custom bestuursorgaan selector
+fields:4c7820f0-4011-4ab4-a16a-e128800e11bc form:hasConditionalFieldGroup fields:6b12b310-8981-4499-bb45-2ef54b704b58.
+
+fields:6b12b310-8981-4499-bb45-2ef54b704b58 a form:ConditionalFieldGroup ;
+    mu:uuid "6b12b310-8981-4499-bb45-2ef54b704b58";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/e27ef237-29de-49b8-be22-4ee2ab2d4e5b> # Toetreding rechtspersoon
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuursorgaanClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/17e76b36-64a1-4db1-8927-def3064b4bf1> # Regionaal bestuurscomité
+      ] ;
+    form:hasFieldGroup fieldGroups:1ed80702-9bec-4b44-ba1f-c033ef35a018 .fieldGroups:907d53dc-de66-4d0c-a54f-e3a8f975b82a a form:FieldGroup ;
+    mu:uuid "907d53dc-de66-4d0c-a54f-e3a8f975b82a" ;
+    form:hasField
+
+                      ###Links-naar-documenten###
+                      fields:1e0f541f-61e9-43a7-bc5f-612eb44f52bb,
+
+                      ###Bestanden###
+                      fields:c7c5a589-0785-4032-a4bd-ee589add3c39.
+
+# this field is the custom bestuursorgaan selector
+fields:4c7820f0-4011-4ab4-a16a-e128800e11bc form:hasConditionalFieldGroup fields:042b9a4f-e67b-4319-9c5c-7665a7c6e965.
+
+fields:042b9a4f-e67b-4319-9c5c-7665a7c6e965 a form:ConditionalFieldGroup ;
+    mu:uuid "042b9a4f-e67b-4319-9c5c-7665a7c6e965";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/e27ef237-29de-49b8-be22-4ee2ab2d4e5b> # Toetreding rechtspersoon
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuursorgaanClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000008> # vast bureau
+      ] ;
+    form:hasFieldGroup fieldGroups:907d53dc-de66-4d0c-a54f-e3a8f975b82a .fieldGroups:2a680569-0262-4030-842e-0925e1348446 a form:FieldGroup ;
+    mu:uuid "2a680569-0262-4030-842e-0925e1348446" ;
+    form:hasField
+
+                      ###Links-naar-documenten###
+                      fields:1e0f541f-61e9-43a7-bc5f-612eb44f52bb,
+
+                      ###Bestanden###
+                      fields:c7c5a589-0785-4032-a4bd-ee589add3c39.
+
+# this field is the custom bestuursorgaan selector
+fields:4c7820f0-4011-4ab4-a16a-e128800e11bc form:hasConditionalFieldGroup fields:b05954eb-73fb-4a68-a8cc-cdf51b7a8e2a.
+
+fields:b05954eb-73fb-4a68-a8cc-cdf51b7a8e2a a form:ConditionalFieldGroup ;
+    mu:uuid "b05954eb-73fb-4a68-a8cc-cdf51b7a8e2a";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/e27ef237-29de-49b8-be22-4ee2ab2d4e5b> # Toetreding rechtspersoon
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuursorgaanClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/53c0d8cd-f3a2-411d-bece-4bd83ae2bbc9> # Voorzitter van het Bijzonder Comité voor de Sociale Dienst
+      ] ;
+    form:hasFieldGroup fieldGroups:2a680569-0262-4030-842e-0925e1348446 .
+
+########### Vaststelling gemeentelijk beleidskader (gemeentewegen) ###########
+
+# Conditionally add the form fields to the "type dossier" field
+fields:0827fafe-ad19-49e1-8b2e-105d2c08a54a form:hasConditionalFieldGroup fields:14cf00b9-af35-4dc7-9a6e-78c7f9b98d2a.
+
+# Only add the fields if the user selected the "Vaststelling gemeentelijk beleidskader (gemeentewegen)" option
+fields:14cf00b9-af35-4dc7-9a6e-78c7f9b98d2a a form:ConditionalFieldGroup ;
+    mu:uuid "14cf00b9-af35-4dc7-9a6e-78c7f9b98d2a";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/b0fcc0c3-bb33-427f-8da2-4ef3833c9060>
+      ] ;
+    form:hasFieldGroup fieldGroups:94b97172-f358-4ffd-b8e7-81898551a97c .
+
+# Fields that should always be added to the current form
+fieldGroups:94b97172-f358-4ffd-b8e7-81898551a97c a form:FieldGroup ;
+    mu:uuid "94b97172-f358-4ffd-b8e7-81898551a97c" ;
+
+    form:hasField
+      ###Gaat het over een voorlopige of definitieve vaststelling?###
+      fields:656c67e2-05e0-41f5-a449-0056d06eb64f,
+
+      ###Datum-zitting/besluit###
+      fields:3dd6ed93-40f7-4d70-a6cb-f4de53dc8bfb,
+
+      ###Welk-beslissingsorgaan-nam-het-besluit?###
+      fields:4c7820f0-4011-4ab4-a16a-e128800e11bc.
+
+
+# Some fields are added conditionally based on the selection of "Gaat het over een voorlopige of definitieve vaststelling?"
+
+## If the selected value is "Definitief"
+fields:656c67e2-05e0-41f5-a449-0056d06eb64f form:hasConditionalFieldGroup fields:e2421a9f-cb0e-4f61-9d4e-2f340e10f9d2.
+
+fields:e2421a9f-cb0e-4f61-9d4e-2f340e10f9d2 a form:ConditionalFieldGroup ;
+    mu:uuid "e2421a9f-cb0e-4f61-9d4e-2f340e10f9d2";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path lblodBesluit:AdoptionType ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/a995bb71-3c87-4385-a06b-a786f2fa0d16> ;
+        form:customValue <http://lblod.data.gift/concepts/28da07ad-4a25-460e-b1be-92bd4b7b8927>
+      ] ;
+    form:hasFieldGroup fieldGroups:541b0bea-bd2b-4e4c-99f4-1b0deb3d6a28 .
+
+fieldGroups:541b0bea-bd2b-4e4c-99f4-1b0deb3d6a28 a form:FieldGroup ;
+    mu:uuid "541b0bea-bd2b-4e4c-99f4-1b0deb3d6a28" ;
+    form:hasField
+      ###Datum-van-publicatie-op-webtoepassing###
+      fields:f63b6a4d-38a2-445d-96c2-f79d248edfca,
+
+      ### Links-naar-documenten ###
+      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b ,
+      
+      ### File uploader with custom help text
+      fields:fc5ff1f9-65ac-4200-8bcb-ec827c2aee01,
+      
+      ###Type RemoteDataObject or FileDataObject###
+      fields:355fe001-cdca-48cc-8a6e-88b3aab09874,
+
+      ### RemoteDataObject/url ###
+      fields:d0052f0d-90bc-4543-a6b0-e90a1c1117db.
+
+## If the selected value is "Voorlopig"
+fields:656c67e2-05e0-41f5-a449-0056d06eb64f form:hasConditionalFieldGroup fields:dcce4bc3-7dbb-4f60-88ea-5ace19c8890a.
+
+fields:dcce4bc3-7dbb-4f60-88ea-5ace19c8890a a form:ConditionalFieldGroup ;
+    mu:uuid "dcce4bc3-7dbb-4f60-88ea-5ace19c8890a";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path lblodBesluit:AdoptionType ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/a995bb71-3c87-4385-a06b-a786f2fa0d16> ;
+        form:customValue <http://lblod.data.gift/concepts/055d66b8-204c-47da-80d9-d41601503616>
+      ] ;
+    form:hasFieldGroup fieldGroups:de6a45ac-e658-4cb7-8c75-d0734c7f76df .
+
+fieldGroups:de6a45ac-e658-4cb7-8c75-d0734c7f76df a form:FieldGroup ;
+    mu:uuid "de6a45ac-e658-4cb7-8c75-d0734c7f76df" ;
+    form:hasField
+      ### Datum-van-publicatie-op-webtoepassing without required validator
+      fields:7d31d717-ee75-4280-996f-2b76bbfa6759,
+
+      ### Links-naar-documenten ###
+      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b ,
+
+      ### File uploader with custom help text
+      fields:0d2a3e6c-81ea-4c24-87b3-4f9cc5512a07,
+      
+      ###Type RemoteDataObject or FileDataObject###
+      fields:355fe001-cdca-48cc-8a6e-88b3aab09874,
+
+      ### RemoteDataObject/url ###
+      fields:d0052f0d-90bc-4543-a6b0-e90a1c1117db.
+
+############################################################################################
+# Custom form fields for the "Vaststelling gemeentelijk beleidskader (gemeentewegen)" form 
+############################################################################################
+
+## Clone of `b9d831c5-da21-40d6-aac8-65feb4783d76` so we can conditionally add fields to it without conflicts in the other form
+fields:656c67e2-05e0-41f5-a449-0056d06eb64f a form:Field ;
+    mu:uuid "656c67e2-05e0-41f5-a449-0056d06eb64f" ;
+    sh:name "Gaat het over een voorlopige of definitieve vaststelling?" ;
+    sh:order 3700 ;
+    sh:path lblodBesluit:AdoptionType ;
+    form:validations
+      [ a form:RequiredConstraint ;
+        form:grouping form:Bag ;
+        sh:path lblodBesluit:AdoptionType ;
+        sh:resultMessage "Dit veld is verplicht."@nl
+      ],
+      [ a form:ConceptSchemeConstraint ;
+        form:grouping form:Bag ;
+        sh:path lblodBesluit:AdoptionType ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/a995bb71-3c87-4385-a06b-a786f2fa0d16>;
+        sh:resultMessage "Selecteer een waarde uit de lijst."@nl
+      ] ;
+    form:options  """{"conceptScheme":"http://lblod.data.gift/concept-schemes/a995bb71-3c87-4385-a06b-a786f2fa0d16"}""" ;
+    form:displayType displayTypes:conceptSchemeRadioButtons ;
+    sh:group fields:aDynamicPropertyGroup .
+
+## Copy of the standard field but with a different ordering
+fields:f63b6a4d-38a2-445d-96c2-f79d248edfca a form:Field ;
+    mu:uuid "f63b6a4d-38a2-445d-96c2-f79d248edfca" ;
+    sh:name "Datum van publicatie op webtoepassing" ;
+    sh:order 3800 ;
+    sh:path eli:date_publication ;
+    form:validations
+      [ a form:RequiredConstraint ;
+        form:grouping form:Bag ;
+        sh:resultMessage "Dit veld is verplicht.";
+        sh:path eli:date_publication ],
+      [ a form:ValidDate ;
+        form:grouping form:MatchEvery ;
+        sh:path eli:date_publication ;
+        sh:resultMessage "Geef een geldige datum op."@nl ] ;
+    form:displayType displayTypes:date ;
+    sh:group fields:aDynamicPropertyGroup .
+
+# Variant of "fields:f63b6a4d-38a2-445d-96c2-f79d248edfca" without the RequiredConstraint
+fields:7d31d717-ee75-4280-996f-2b76bbfa6759 a form:Field ;
+    mu:uuid "7d31d717-ee75-4280-996f-2b76bbfa6759" ;
+    sh:name "Datum van publicatie op webtoepassing" ;
+    sh:order 3800 ;
+    sh:path eli:date_publication ;
+    form:validations
+      [ a form:ValidDate ;
+        form:grouping form:MatchEvery ;
+        sh:path eli:date_publication ;
+        sh:resultMessage "Geef een geldige datum op."@nl ] ;
+    form:displayType displayTypes:date ;
+    sh:group fields:aDynamicPropertyGroup .
+
+## File upload with custom help text which should be shown when "Definitief" is selected
+fields:fc5ff1f9-65ac-4200-8bcb-ec827c2aee01 a form:Field ;
+    mu:uuid "fc5ff1f9-65ac-4200-8bcb-ec827c2aee01" ;
+    sh:name "Bestanden" ;
+    sh:order 10001 ;
+    sh:path dct:hasPart;
+    form:validations
+     [ a  form:RequiredConstraint ;
+          form:grouping form:Bag ;
+          sh:path dct:hasPart;
+          sh:resultMessage "Gelieve minstens één URL of bestand op te geven."@nl # TODO: later custom validator
+     ];
+    form:displayType displayTypes:files; # consider this v1.0
+    form:help """Volgende documenten moeten bezorgd worden: uittreksel uit de gemeenteraad met de definitieve beslissing, gemeentelijk beleidskader, gemeentelijk actieplan (indien opgemaakt).""" ;
+    sh:group fields:aDynamicPropertyGroup .
+
+## File upload with custom help text which should be shown when "Voorlopig" is selected
+fields:0d2a3e6c-81ea-4c24-87b3-4f9cc5512a07 a form:Field ;
+    mu:uuid "0d2a3e6c-81ea-4c24-87b3-4f9cc5512a07" ;
+    sh:name "Bestanden" ;
+    sh:order 10001 ;
+    sh:path dct:hasPart;
+    form:validations
+     [ a  form:RequiredConstraint ;
+          form:grouping form:Bag ;
+          sh:path dct:hasPart;
+          sh:resultMessage "Gelieve minstens één URL of bestand op te geven."@nl # TODO: later custom validator
+     ];
+    form:displayType displayTypes:files; # consider this v1.0
+    form:help """
+    <div class="au-c-content au-c-content--tiny">
+      <p>
+        Volgende documenten moeten bezorgd worden: uittreksel uit de gemeenteraad met de voorlopige beslissing, 
+        ontwerp gemeentelijk beleidskader, ontwerp gemeentelijk actieplan (indien opgemaakt).
+      </p>
+      <p>
+        Het Departement MOW verleent momenteel enkel niet-dossierspecifiek advies. Het decreet Gemeentewegen kent nieuwe
+        taken toe aan het Departement. Gezien de vrij recente goedkeuring van dit decreet en de mogelijke impact op de 
+        organisatie loopt de transitie die gepaard gaat met het opnemen van deze taken momenteel nog. We willen benadrukken dat uw 
+        beslissing moet voldoen aan de doelstellingen en principes zoals geformuleerd in artikel 3 en 4 van het decreet Gemeentewegen:
+      </p>
+      <ul>
+        <li>het belang van de huidige en toekomstige behoeften van de zachte mobiliteit staat voorop.</li>
+        <li>
+          de noodzaak om een geïntegreerd beleid te voeren, dat leidt tot de uitbouw van veilige wegen op lokaal niveau 
+          en op de herwaardering en bescherming van de trage wegen.
+        </li>
+      </ul>
+      <p>
+        Het gemeentelijk beleidskader moet dan ook altijd van algemeen belang zijn, waarbij wijzigingen en afschaffingen van wegen
+        uitzonderingsmaatregelen zijn. Het is ook van belang om de wijzigingen te bekijken in een ruimere context dan enkel het 
+        eigen gemeentelijk niveau. Verder vragen we u de vormvereisten van het decreet Gemeentewegen na te leven, oog te hebben
+        voor de eventuele meer- en minwaarden die het dossier met zich kan meebrengen en het goede huisvader-principe niet te verwaarlozen.
+      </p>
+    </div>""" ;
+    sh:group fields:aDynamicPropertyGroup .
+
+###########Definitieve aanleg, verplaatsing of wijziging van een gemeenteweg###########
+
+fieldGroups:f7e0c669-2634-4264-b01f-cc76cfa24b1a a form:FieldGroup ;
+    mu:uuid "f7e0c669-2634-4264-b01f-cc76cfa24b1a" ;
+    form:hasField
+                      ###Links-naar-documenten###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b ,
+
+                      ###Bestanden###
+                      fields:43c48290-8cc0-4066-aeee-8545bca7c68d, # with custom helper text
+
+                      ###Type RemoteDataObject or FileDataObject###
+                      fields:355fe001-cdca-48cc-8a6e-88b3aab09874,
+
+                      ### RemoteDataObject/url ###
+                      fields:d0052f0d-90bc-4543-a6b0-e90a1c1117db.
+
+fields:b9d831c5-da21-40d6-aac8-65feb4783d76 form:hasConditionalFieldGroup fields:f831b57d-905a-4002-9a1d-60d2723c6672.
+
+fields:f831b57d-905a-4002-9a1d-60d2723c6672 a form:ConditionalFieldGroup ;
+    mu:uuid "f831b57d-905a-4002-9a1d-60d2723c6672";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path lblodBesluit:AdoptionType ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/a995bb71-3c87-4385-a06b-a786f2fa0d16> ;
+        form:customValue <http://lblod.data.gift/concepts/28da07ad-4a25-460e-b1be-92bd4b7b8927>
+      ] ,
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path lblodBesluit:MunicipalRoadProcedureType ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/60d620a5-ec34-4a91-ba84-fff0813d0ccc> ;
+        form:customValue <http://lblod.data.gift/concepts/0588da5c-08b2-4209-ab3c-efd1b94e1326>
+      ] ;
+    form:hasFieldGroup fieldGroups:f7e0c669-2634-4264-b01f-cc76cfa24b1a .
+
+###########Definitieve Opheving###########
+
+fieldGroups:98a3e371-6c90-446b-8547-901e47d3b047 a form:FieldGroup ;
+    mu:uuid "98a3e371-6c90-446b-8547-901e47d3b047" ;
+    form:hasField
+                      ###Links-naar-documenten###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,
+
+                      ###Bestanden###
+                      fields:2aecc67c-687d-448c-be01-94ad42fb51c1, # with custom helper text
+
+                      ###Type RemoteDataObject or FileDataObject###
+                      fields:355fe001-cdca-48cc-8a6e-88b3aab09874,
+
+                      ### RemoteDataObject/url ###
+                      fields:d0052f0d-90bc-4543-a6b0-e90a1c1117db.
+
+fields:b9d831c5-da21-40d6-aac8-65feb4783d76 form:hasConditionalFieldGroup fields:083a2c18-e46b-4f2a-a29d-358412f310bf.
+
+fields:083a2c18-e46b-4f2a-a29d-358412f310bf a form:ConditionalFieldGroup ;
+    mu:uuid "083a2c18-e46b-4f2a-a29d-358412f310bf";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path lblodBesluit:AdoptionType ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/a995bb71-3c87-4385-a06b-a786f2fa0d16> ;
+        form:customValue <http://lblod.data.gift/concepts/28da07ad-4a25-460e-b1be-92bd4b7b8927>
+      ] ,
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path lblodBesluit:MunicipalRoadProcedureType ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/60d620a5-ec34-4a91-ba84-fff0813d0ccc> ;
+        form:customValue <http://lblod.data.gift/concepts/82813418-356b-49a6-be9e-c5ef1b7a70bc>
+      ] ;
+    form:hasFieldGroup fieldGroups:98a3e371-6c90-446b-8547-901e47d3b047 .
+
+###########Vaststelling gemeenteweg###########
+
+fieldGroups:c7d584e4-ebd8-49d5-a570-11670200d7b9 a form:FieldGroup ;
+    mu:uuid "c7d584e4-ebd8-49d5-a570-11670200d7b9" ;
+    form:hasField
+
+                      ###Gaat het over een voorlopige of definitieve vaststelling?###
+                      fields:b9d831c5-da21-40d6-aac8-65feb4783d76,
+
+                      ###Gaat het over een aanleg/verplaatsing/wijziging of over een opheffing van een gemeenteweg?###
+                      fields:a7073ee1-3717-4798-ae10-fe69b29fabc1,
+
+                      ###Datum-zitting/besluit###
+                      fields:3dd6ed93-40f7-4d70-a6cb-f4de53dc8bfb,
+
+                      ###Datum-van-publicatie-op-webtoepassing###
+                      fields:49dbe1be-877a-4890-8465-1510ff18ce18,
+
+                      ###Welk-beslissingsorgaan-nam-het-besluit?###
+                      fields:4c7820f0-4011-4ab4-a16a-e128800e11bc.
+
+fields:0827fafe-ad19-49e1-8b2e-105d2c08a54a form:hasConditionalFieldGroup fields:5b5ed2f1-f7be-49b7-bbcf-e1eece89b10c.
+
+fields:5b5ed2f1-f7be-49b7-bbcf-e1eece89b10c a form:ConditionalFieldGroup ;
+    mu:uuid "5b5ed2f1-f7be-49b7-bbcf-e1eece89b10c";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/f1fd8f88-95b0-4085-b766-008b5867d992>
+      ] ;
+    form:hasFieldGroup fieldGroups:c7d584e4-ebd8-49d5-a570-11670200d7b9 .
+
+
+
+###########Voorlopige aanleg, verplaatsing of wijziging###########
+
+fieldGroups:5e1cc9c8-59df-4802-a1d5-f776b6364617 a form:FieldGroup ;
+    mu:uuid "5e1cc9c8-59df-4802-a1d5-f776b6364617" ;
+    form:hasField
+                      ###Links-naar-documenten###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,
+
+                      ###Bestanden###
+                      fields:f1fa5e64-1c68-4355-894a-2e0531f4412f, # with custom helper text
+
+                      ###Type RemoteDataObject or FileDataObject###
+                      fields:355fe001-cdca-48cc-8a6e-88b3aab09874,
+
+                      ### RemoteDataObject/url ###
+                      fields:d0052f0d-90bc-4543-a6b0-e90a1c1117db.
+
+fields:b9d831c5-da21-40d6-aac8-65feb4783d76 form:hasConditionalFieldGroup fields:c9dfaf9c-31cb-4443-8084-bf383fb950b8.
+
+fields:c9dfaf9c-31cb-4443-8084-bf383fb950b8 a form:ConditionalFieldGroup ;
+    mu:uuid "c9dfaf9c-31cb-4443-8084-bf383fb950b8";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path lblodBesluit:AdoptionType ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/a995bb71-3c87-4385-a06b-a786f2fa0d16> ;
+        form:customValue <http://lblod.data.gift/concepts/055d66b8-204c-47da-80d9-d41601503616>
+      ] ,
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path lblodBesluit:MunicipalRoadProcedureType ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/60d620a5-ec34-4a91-ba84-fff0813d0ccc> ;
+        form:customValue <http://lblod.data.gift/concepts/0588da5c-08b2-4209-ab3c-efd1b94e1326>
+      ] ;
+    form:hasFieldGroup fieldGroups:5e1cc9c8-59df-4802-a1d5-f776b6364617 .
+
+###########Voorlopige Opheving###########
+
+fieldGroups:6f7eeed2-6f6e-4999-b225-a43ed0de5e4c a form:FieldGroup ;
+    mu:uuid "6f7eeed2-6f6e-4999-b225-a43ed0de5e4c" ;
+    form:hasField
+                      ###Links-naar-documenten###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,
+
+                      ###Bestanden###
+                      fields:6f7cb360-26df-4233-988a-a11ac9c33ba4, # with custom helper text
+
+                      ###Type RemoteDataObject or FileDataObject###
+                      fields:355fe001-cdca-48cc-8a6e-88b3aab09874,
+
+                      ### RemoteDataObject/url ###
+                      fields:d0052f0d-90bc-4543-a6b0-e90a1c1117db.
+
+fields:b9d831c5-da21-40d6-aac8-65feb4783d76 form:hasConditionalFieldGroup fields:20f49493-ff36-49c2-bb6f-e1711f8799d2.
+
+fields:20f49493-ff36-49c2-bb6f-e1711f8799d2 a form:ConditionalFieldGroup ;
+    mu:uuid "20f49493-ff36-49c2-bb6f-e1711f8799d2";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path lblodBesluit:AdoptionType ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/a995bb71-3c87-4385-a06b-a786f2fa0d16> ;
+        form:customValue <http://lblod.data.gift/concepts/055d66b8-204c-47da-80d9-d41601503616>
+      ] ,
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path lblodBesluit:MunicipalRoadProcedureType ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/60d620a5-ec34-4a91-ba84-fff0813d0ccc> ;
+        form:customValue <http://lblod.data.gift/concepts/82813418-356b-49a6-be9e-c5ef1b7a70bc>
+      ] ;
+    form:hasFieldGroup fieldGroups:6f7eeed2-6f6e-4999-b225-a43ed0de5e4c .
+
+###########Verslag-lokale-betrokkenheid-eredienstbesturen###########
+
+fieldGroups:319fc495-408d-4b3d-b217-dcbdf6f414d5 a form:FieldGroup ;
+    mu:uuid "319fc495-408d-4b3d-b217-dcbdf6f414d5" ; 
+    form:hasField 
+                      ###Naam-betreffend-bedrijf/bestuur###
+                      fields:78bfbd91-0778-4573-a52d-4c53b3c512eb,
+
+                      ###Ondernemingsnummer-betreffend-bedrijf/bestuur###
+                      fields:6ffb0ed7-769a-41e4-b5a9-f6fb0287b235,
+
+                      ###Datum-zitting/besluit###
+                      fields:3dd6ed93-40f7-4d70-a6cb-f4de53dc8bfb,
+
+                      ###Datum-zitting/besluit###
+                      fields:3dd6ed93-40f7-4d70-a6cb-f4de53dc8bfb,
+
+                      ###Welk-beslissingsorgaan-nam-het-besluit?###
+                      fields:bffbea8d-e55b-4e3d-86e8-ba7aaee7863d,
+
+                      ###Naam-betreffend-bedrijf/bestuur###
+                      fields:78bfbd91-0778-4573-a52d-4c53b3c512eb,
+
+                      ###Ondernemingsnummer-betreffend-bedrijf/bestuur###
+                      fields:6ffb0ed7-769a-41e4-b5a9-f6fb0287b235,
+
+                      ###Links-naar-documenten###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,
+
+                      ###Bestanden###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95a,
+
+                      ###Type RemoteDataObject or FileDataObject###
+                      fields:355fe001-cdca-48cc-8a6e-88b3aab09874,
+
+                      ### RemoteDataObject/url ###
+                      fields:d0052f0d-90bc-4543-a6b0-e90a1c1117db.
+                      
+fields:0827fafe-ad19-49e1-8b2e-105d2c08a54a form:hasConditionalFieldGroup fields:d99c663e-32ae-4865-bdeb-f961fda68d61.
+
+fields:d99c663e-32ae-4865-bdeb-f961fda68d61 a form:ConditionalFieldGroup ;
+    mu:uuid "d99c663e-32ae-4865-bdeb-f961fda68d61";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitDocumentType/e274f1b1-7e84-457d-befe-070afec6b752>
+      ] ;
+    form:hasFieldGroup fieldGroups:319fc495-408d-4b3d-b217-dcbdf6f414d5 .
+
+########### Voorstellen in verband met het saneringsplan ###########
+
+# Conditionally add the form fields to the "type dossier" field
+fields:0827fafe-ad19-49e1-8b2e-105d2c08a54a form:hasConditionalFieldGroup fields:4faea096-c61b-4495-84f6-5cccf154226e.
+
+# Only add the fields if the user selected the "Voorstellen in verband met het saneringsplan" option
+fields:4faea096-c61b-4495-84f6-5cccf154226e a form:ConditionalFieldGroup ;
+    mu:uuid "4faea096-c61b-4495-84f6-5cccf154226e";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/4511f992-2b52-42fe-9cb6-feae6241ad26>
+      ] ;
+    form:hasFieldGroup fieldGroups:3670383c-6d1c-4959-b27d-cfd616fa8035 .
+
+fieldGroups:3670383c-6d1c-4959-b27d-cfd616fa8035 a form:FieldGroup ;
+    mu:uuid "3670383c-6d1c-4959-b27d-cfd616fa8035" ;
+
+    form:hasField
+      ### Welk-beslissingsorgaan-nam-het-besluit? ###
+      fields:4c7820f0-4011-4ab4-a16a-e128800e11bc,
+
+      ### Datum-zitting/besluit ###
+      fields:3dd6ed93-40f7-4d70-a6cb-f4de53dc8bfb,
+
+      ### Datum van publicatie op webtoepassing
+      fields:49dbe1be-877a-4890-8465-1510ff18ce18,
+
+      ### Simple field for URL (required & valid URL) ###
+      fields:1f41766c-2ae4-4dd2-b6ba-7ceedadd3430,
+
+      ### Hidden field required for all variations of URL or FILE ###
+      fields:355fe001-cdca-48cc-8a6e-88b3aab09874,
+
+      ### RemoteDataObject/url ###
+      fields:d0052f0d-90bc-4543-a6b0-e90a1c1117db.
+
+############################################################################################
+# Custom form fields for the "Voorstellen in verband met het saneringsplan" form
+############################################################################################
+
+## Simple field for URL (required & valid URL) with custom help text
+fields:1f41766c-2ae4-4dd2-b6ba-7ceedadd3430 a form:Field ;
+    mu:uuid "1f41766c-2ae4-4dd2-b6ba-7ceedadd3430" ;
+    sh:name "Links naar documenten" ;
+    sh:order 10000 ;
+    sh:path dct:hasPart;
+    form:validations
+     [ a form:UriConstraint ;
+        form:grouping form:MatchEvery ;
+        sh:resultMessage "Gelieve een geldige URL op te geven. Zorg dat vooraan in de link altijd http://, https://, ftp:// of sftp:// staat."; # TODO: later custom validator
+         sh:path ( dct:hasPart nie:url ) ],
+     [ a form:RequiredConstraint ;
+         form:grouping form:Bag ;
+         sh:path ( dct:hasPart nie:url ) ;
+         sh:resultMessage "Gelieve minstens één URL op te geven."@nl
+     ];
+    form:displayType <http://lblod.data.gift/display-types/remoteUrls/variation/1>;
+    form:help """
+    <div class="au-c-content au-c-content--tiny">
+      <p>
+        De voorstellen van de raad van bestuur om de continuïteit van de vereniging te vrijwaren ('het plan overeenkomstig artikel 457 DLB')
+        moeten gepubliceerd worden op de website van de vereniging, binnen 10 dagen nadat de besluiten genomen zijn (art. 467, eerste lid, 2° DLB).
+      </p>
+      <p>
+        Op dezelfde dag als deze publicatie op uw website, moet u hier een melding maken dat u de voorstellen hebt gepubliceerd, met daarbij
+        een link naar uw eigen website waar de voorstellen zijn gepubliceerd (art. 467, vierde lid DLB). U moet hier dus niet het besluit zelf opladen.
+      </p>
+    </div>""" ;
+    sh:group fields:aDynamicPropertyGroup .
+
+
+###########Wijziging-autonoom-bedrijf###########
+
+fieldGroups:d450b149-4372-40d9-bd31-ee1f1402c630 a form:FieldGroup ;
+    mu:uuid "d450b149-4372-40d9-bd31-ee1f1402c630" ; 
+    form:hasField 
+                      ###Dossieromschrijving###
+                      fields:bd6ee5ac-22d6-4279-bcba-3ed279021aac,
+
+                      ###Ondernemingsnummer-betreffend-bedrijf/bestuur###
+                      fields:6ffb0ed7-769a-41e4-b5a9-f6fb0287b235,
+
+                      ###Naam-betreffend-bedrijf/bestuur###
+                      fields:78bfbd91-0778-4573-a52d-4c53b3c512eb,
+
+                      ###Datum-zitting/besluit###
+                      fields:3dd6ed93-40f7-4d70-a6cb-f4de53dc8bfb,
+
+                      ###Datum-zitting/besluit###
+                      fields:3dd6ed93-40f7-4d70-a6cb-f4de53dc8bfb,
+
+                      ###Datum-van-publicatie-op-webtoepassing###
+                      fields:49dbe1be-877a-4890-8465-1510ff18ce18,
+
+                      ###Dossieromschrijving###
+                      fields:bd6ee5ac-22d6-4279-bcba-3ed279021aac,
+
+                      ###Ondernemingsnummer-betreffend-bedrijf/bestuur###
+                      fields:6ffb0ed7-769a-41e4-b5a9-f6fb0287b235,
+
+                      ###Naam-betreffend-bedrijf/bestuur###
+                      fields:78bfbd91-0778-4573-a52d-4c53b3c512eb,
+
+                      ###Welk-beslissingsorgaan-nam-het-besluit?###
+                      fields:4c7820f0-4011-4ab4-a16a-e128800e11bc,
+
+                      ###Links-naar-documenten###
+                      fields:1e0f541f-61e9-43a7-bc5f-612eb44f52bb,
+
+                      ###Bestanden###
+                      fields:c7c5a589-0785-4032-a4bd-ee589add3c39,
+
+                      ###Type RemoteDataObject or FileDataObject###
+                      fields:355fe001-cdca-48cc-8a6e-88b3aab09874,
+
+                      ### RemoteDataObject/url ###
+                      fields:d0052f0d-90bc-4543-a6b0-e90a1c1117db.
+                      
+fields:0827fafe-ad19-49e1-8b2e-105d2c08a54a form:hasConditionalFieldGroup fields:70be2b17-d91e-454b-8fda-a041432d94e8.
+
+fields:70be2b17-d91e-454b-8fda-a041432d94e8 a form:ConditionalFieldGroup ;
+    mu:uuid "70be2b17-d91e-454b-8fda-a041432d94e8";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/c945b531-4742-43fe-af55-b13da6ecc6fe>
+      ] ;
+    form:hasFieldGroup fieldGroups:d450b149-4372-40d9-bd31-ee1f1402c630 .
+
+fieldGroups:9a990f56-f8a4-11ea-b10d-936a9491d84b a form:FieldGroup ;
+    mu:uuid "9a990f56-f8a4-11ea-b10d-936a9491d84b" ;
+    form:hasField
+
+                      ###Links-naar-documenten###
+                      fields:1e0f541f-61e9-43a7-bc5f-612eb44f52bb,
+
+                      ###Bestanden###
+                      fields:c7c5a589-0785-4032-a4bd-ee589add3c39.
+
+# this field is the custom bestuursorgaan selector
+fields:4c7820f0-4011-4ab4-a16a-e128800e11bc form:hasConditionalFieldGroup fields:cfa2e2bc-f8a4-11ea-aab6-a36dfc0a5d1f.
+
+fields:cfa2e2bc-f8a4-11ea-aab6-a36dfc0a5d1f a form:ConditionalFieldGroup ;
+    mu:uuid "cfa2e2bc-f8a4-11ea-aab6-a36dfc0a5d1f";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/d9c3d177-6dc6-4775-8c6a-1055a9cbdcc6>
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuursorgaanClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> # Algemene vergadering
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:bestuurt besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuurseenheidClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/cc4e2d67-603b-4784-9b61-e50bac1ec089> # OCMWV
+      ] ;
+    form:hasFieldGroup fieldGroups:9a990f56-f8a4-11ea-b10d-936a9491d84b .###########Wijziging-ocmw-vereniging###########
+
+fieldGroups:8f69f627-e0f0-44e9-95f2-7db5e421f0fc a form:FieldGroup ;
+    mu:uuid "8f69f627-e0f0-44e9-95f2-7db5e421f0fc" ;
+    form:hasField
+                      ###Ondernemingsnummer-betreffend-bedrijf/bestuur###
+                      fields:6ffb0ed7-769a-41e4-b5a9-f6fb0287b235,
+
+                      ###Naam-betreffend-bedrijf/bestuur###
+                      fields:78bfbd91-0778-4573-a52d-4c53b3c512eb,
+
+                      ###Datum-zitting/besluit###
+                      fields:3dd6ed93-40f7-4d70-a6cb-f4de53dc8bfb,
+
+                      ###Datum-van-publicatie-op-webtoepassing###
+                      fields:49dbe1be-877a-4890-8465-1510ff18ce18,
+
+                      ###Datum-zitting/besluit###
+                      fields:3dd6ed93-40f7-4d70-a6cb-f4de53dc8bfb,
+
+                      ###Ondernemingsnummer-betreffend-bedrijf/bestuur###
+                      fields:6ffb0ed7-769a-41e4-b5a9-f6fb0287b235,
+
+                      ###Naam-betreffend-bedrijf/bestuur###
+                      fields:78bfbd91-0778-4573-a52d-4c53b3c512eb,
+
+                      ###Welk-beslissingsorgaan-nam-het-besluit?###
+                      fields:4c7820f0-4011-4ab4-a16a-e128800e11bc,
+
+                      ###Type RemoteDataObject or FileDataObject###
+                      fields:355fe001-cdca-48cc-8a6e-88b3aab09874,
+
+                      ### RemoteDataObject/url ###
+                      fields:d0052f0d-90bc-4543-a6b0-e90a1c1117db,
+
+                      ### Bestuursorgaan classificatie code [hidden input] ###
+                      fields:303545a6-705b-43b3-86b7-b96436524be9,
+
+                      ### Bestuurseenheid classificatie code [hidden input] ###
+                      fields:ac32a491-4b5c-4a7e-973f-fad6127c9433.
+
+fields:0827fafe-ad19-49e1-8b2e-105d2c08a54a form:hasConditionalFieldGroup fields:0ae400e4-6897-4d86-982a-e1f74ead1f93.
+
+fields:0ae400e4-6897-4d86-982a-e1f74ead1f93 a form:ConditionalFieldGroup ;
+    mu:uuid "0ae400e4-6897-4d86-982a-e1f74ead1f93";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/d9c3d177-6dc6-4775-8c6a-1055a9cbdcc6>
+      ] ;
+    form:hasFieldGroup fieldGroups:8f69f627-e0f0-44e9-95f2-7db5e421f0fc .
+fieldGroups:a3a1b08e-f8a5-11ea-883f-274cf7199c4a a form:FieldGroup ;
+    mu:uuid "a3a1b08e-f8a5-11ea-883f-274cf7199c4a" ;
+    form:hasField
+
+                      ###Links-naar-documenten###
+                      fields:1e0f541f-61e9-43a7-bc5f-612eb44f52bb,
+
+                      ###Bestanden###
+                      fields:c7c5a589-0785-4032-a4bd-ee589add3c39.
+
+# this field is the custom bestuursorgaan selector
+fields:4c7820f0-4011-4ab4-a16a-e128800e11bc form:hasConditionalFieldGroup fields:bb0cb84a-f8a5-11ea-a0f4-0fbac219f72e.
+
+fields:bb0cb84a-f8a5-11ea-a0f4-0fbac219f72e a form:ConditionalFieldGroup ;
+    mu:uuid "bb0cb84a-f8a5-11ea-a0f4-0fbac219f72e";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/d9c3d177-6dc6-4775-8c6a-1055a9cbdcc6>
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuursorgaanClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> # Raad van bestuur
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:bestuurt besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuurseenheidClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/cc4e2d67-603b-4784-9b61-e50bac1ec089> # OCMWV
+      ] ;
+    form:hasFieldGroup fieldGroups:a3a1b08e-f8a5-11ea-883f-274cf7199c4a .form:a0a120d2-87a8-4f45-a61b-61654997cf1e a form:Form ;
+    mu:uuid "a0a120d2-87a8-4f45-a61b-61654997cf1e" ;
+    form:hasFieldGroup fieldGroups:allForms .
+fieldGroups:allForms a form:FieldGroup;
+    mu:uuid "3a60def6-107e-4716-bc5f-2f2e108f7fab" ;
+    form:hasField fields:0827fafe-ad19-49e1-8b2e-105d2c08a54a.
+
+fields:aDynamicPropertyGroup a form:PropertyGroup;
+    mu:uuid "8c71b3db-db4b-45ea-8333-ab000adcca4e";
+    sh:description "A dynamic property group";
+    sh:order 3;
+    sh:name "aDynamicPropertyGroup".

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ x-logging:
 
 services:
   frontend:
-    image: lblod/frontend-public-decisions:1.5.0
+    image: lblod/frontend-public-decisions:1.6.0
     volumes:
       - ./config/frontend:/config
     labels:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -157,7 +157,7 @@ services:
       - ./config/semantic-forms:/share/semantic-forms
       - ./data/files/submissions:/share/submissions
     environment:
-      ACTIVE_FORM_FILE: "share://semantic-forms/20230413154257-forms.ttl"
+      ACTIVE_FORM_FILE: "share://semantic-forms/20230621124520-forms.ttl"
       PUBLIC_GRAPH: "http://mu.semte.ch/graphs/access-for-role/PubliekeBesluitendatabank-BesluitendatabankLezer"
       FILE_GRAPH: "http://mu.semte.ch/graphs/access-for-role/PubliekeBesluitendatabank-BesluitendatabankLezer"
     labels:


### PR DESCRIPTION
# Description
DL-5180

This PR is about adjusting the besluit handhaven form.

- "Besluit handhaven" form is now relabeled "Besluit handhaven na ontvangst schorsingsbesluit".

- Adding semantic form migration where we include a new custom field "alert" where it shows the following alert message -> “Met dit formulier kan je een besluit van het bestuur handhaven, na ontvangst van het schorsingsbesluit van de provinciegouverneur of de toezichthoudende gemeente of provincie.“


# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

# Related services

- N/A

# How to test 

- https://github.com/lblod/manage-submission-form-tooling#testing-changes

# What to check

- Any unexpected behavior

# Links to other PR's

- https://github.com/lblod/manage-submission-form-tooling/pull/37

# Notes

- Bump frontend after frontend release