### PR TITLE
[DL-7179]: Add gemeenteweg decision types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ docker-compose.override.yml
 config/migrations/*-sensitive*
 config/search/*.store
 .env
+/data/files/
+/data/tika/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,13 @@
 # Changelog
+## Unreleased
+- Add gemeenteweg decision types [DL-7179]
+
+### Deploy Notes
+
+```
+drc restart migrations && drc logs -ft --tail=200 migrations
+```
+
 ## v1.25.2 (2025-02-05)
   - Fix mu-search config: ensure a ignore groups are added. [DL-7140]
 

--- a/config/migrations/2026/20260413142904-gemeenteweg-dossier-types.graph
+++ b/config/migrations/2026/20260413142904-gemeenteweg-dossier-types.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/public

--- a/config/migrations/2026/20260413142904-gemeenteweg-dossier-types.graph
+++ b/config/migrations/2026/20260413142904-gemeenteweg-dossier-types.graph
@@ -1,1 +1,1 @@
-http://mu.semte.ch/graphs/public
+http://mu.semte.ch/graphs/access-for-role/PubliekeBesluitendatabank-BesluitendatabankLezer

--- a/config/migrations/2026/20260413142904-gemeenteweg-dossier-types.ttl
+++ b/config/migrations/2026/20260413142904-gemeenteweg-dossier-types.ttl
@@ -1,0 +1,24 @@
+@prefix conceptscheme:                    <https://data.vlaanderen.be/id/conceptscheme/> .
+@prefix BesluitType:                      <https://data.vlaanderen.be/id/concept/BesluitType/> .
+@prefix skos:                             <http://www.w3.org/2004/02/skos/core#> .
+@prefix core:                             <http://mu.semte.ch/vocabularies/core/> .
+
+BesluitType:b0fcc0c3-bb33-427f-8da2-4ef3833c9060
+    a skos:Concept, <http://www.w3.org/2000/01/rdf-schema#Class> ;
+    core:uuid "b0fcc0c3-bb33-427f-8da2-4ef3833c9060" ;
+    skos:definition "Besluit van de gemeenteraad tot voorlopige of definitieve vaststelling van het gemeentelijk beleidskader (art. 6, §2 Gemeentewegendecreet)." ;
+    skos:prefLabel "Vaststelling gemeentelijk beleidskader (gemeentewegen)"@nl ;
+    skos:inScheme conceptscheme:BesluitType ;
+    skos:inScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+    skos:topConceptOf conceptscheme:BesluitType ;
+    skos:topConceptOf <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> .
+
+BesluitType:f1fd8f88-95b0-4085-b766-008b5867d992
+    a skos:Concept, <http://www.w3.org/2000/01/rdf-schema#Class> ;
+    core:uuid "f1fd8f88-95b0-4085-b766-008b5867d992" ;
+    skos:definition "Besluit van de gemeenteraad tot voorlopige of definitieve vaststelling van het gemeentelijk rooilijnplan (art. 17 Gemeentewegendecreet)." ;
+    skos:prefLabel "Vaststelling gemeenteweg"@nl ;
+    skos:inScheme conceptscheme:BesluitType ;
+    skos:inScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+    skos:topConceptOf conceptscheme:BesluitType ;
+    skos:topConceptOf <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> .


### PR DESCRIPTION
This PR adds the Decision Types for gemeenteweg, based on the data in Centrale Vindplaats. Notification rules are omitted as these are not usually added to Public Decisions Database.